### PR TITLE
chore(renovate): move keycloak specifics to repository

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -156,34 +156,6 @@
       ],
       extractVersion: "^v(?<version>.*)$",
     },
-    // KeyCloak
-    {
-      matchManagers: ["dockerfile"],
-      groupName: "new major keycloak available",
-      groupSlug: "new-major-keycloak",
-      matchDatasources: ["docker"],
-      matchFileNames: [".watch-latest/Dockerfile"],
-      matchUpdateTypes: ["major"],
-      enabled: true,
-      addLabels: ["dependencies", "docker", "hold"],
-    },
-    {
-      matchManagers: ["dockerfile"],
-      groupName: "all non-major keycloak",
-      groupSlug: "all-non-major-keycloak",
-      matchDatasources: ["docker"],
-      matchFileNames: ["keycloak-*/Dockerfile"],
-      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.+)(?<build>\\d+)-r(?<revision>\\d+))?$",
-      enabled: true,
-      addLabels: ["dependencies", "docker"],
-    },
-    {
-      matchManagers: ["dockerfile"],
-      matchDatasources: ["docker"],
-      matchFileNames: ["keycloak-*/Dockerfile"],
-      matchUpdateTypes: ["major"],
-      enabled: false,
-    },
   ],
   customManagers: [
    {


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/196

we decided to move KeyCloak specifics to its repository.