### PR TITLE
chore(asdf): extract eksctl version

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -148,6 +148,7 @@
     {
       matchFileNames: ["**/.tool-versions", "**/*.tf"],
       matchPackageNames: [
+        "eksctl-io/eksctl",
         "hashicorp/terraform",
         "helm/helm",
         "koalaman/shellcheck",


### PR DESCRIPTION
extracts the version for eksctl as the new config doesn't track it.

related to https://github.com/camunda/team-infrastructure-experience/issues/196