### PR TITLE
chore(renovate): switch to matchDepPatterns where required

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -101,7 +101,7 @@
     // but it's fine to have candidate packages to test before move them to minor section.
     {
       matchUpdateTypes: ["patch"],
-      matchPackagePatterns: [
+      matchDepPatterns: [
         "^terraform$",
         "aquasecurity/tfsec",
         "pre-commit",


### PR DESCRIPTION
fixes the warning about `Use matchDepPatterns instead of matchPackagePatterns`

```
matchPackagePatterns will try matching packageName first and then fall back to matching depName. If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release. Use matchDepPatterns instead.
```

related to https://github.com/camunda/team-infrastructure-experience/issues/196