### PR TITLE
feat: implement silence failure

### DIFF
--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -55,7 +55,7 @@ runs:
         if [ "$ISSUE_COUNT" -gt 0 ]; then
           ISSUE_TITLE=$(echo "$ISSUE_SEARCH" | jq -r '.[0].title')
           ISSUE_URL=$(echo "$ISSUE_SEARCH" | jq -r '.[0].url')
-          echo "Issue found: $ISSUE_TITLE - $ISSUE_URL. Skipping notification. Close this issue to re-enable notifications."
+          echo "Issue found: $ISSUE_TITLE - $ISSUE_URL . Skipping notification. Close this issue to re-enable notifications."
           exit 0
         else
           echo "No silence issue found, triggering the slack alert."

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -27,9 +27,6 @@
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
 
-        - name: Simulate error
-          run: exit 1
-
         - name: Import Secrets
           id: secrets
           uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3
@@ -98,10 +95,9 @@
       needs:
         - aws-nightly-cleanup
       steps:
-        - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-
         - name: Notify in Slack in case of failure
           id: slack-notification
+          if: github.event_name == 'schedule'
           uses: ./.github/actions/report-failure-on-slack
           with:
             vault_addr: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
This PR introduces a mechanism to silence workflow errors by creating an issue in the repository name `silence: WORKFLOW_NAME` with an associated label `alert-management`.
The label ensures that only repo owners can create such issues.

workflow run with no silence issue created: https://github.com/camunda/infraex-common-config/actions/runs/9496241452/job/26170313522
workflow run with a silence issue created: https://github.com/camunda/infraex-common-config/actions/runs/9496415184/job/26170768666
associated silence issue: https://github.com/camunda/infraex-common-config/issues/16