### PR TITLE
chore: group pin and digest updates of renovate with patch

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -39,6 +39,14 @@
   },
   packageRules: [
     {
+      "matchUpdateTypes": [
+        "pin",
+        "digest"
+      ],
+      "enabled": true,
+      groupName: "patch-grouped", // Group all pin and digests updates in a single branch with patch to save CI computing.
+    },
+    {
       matchPackageNames: ["camunda-platform"],
       addLabels: ["group:camunda-platform"],
     },


### PR DESCRIPTION
In https://github.com/camunda/infraex-common-config/pull/20/files I forgot to group pin and digest, this pr fix this
Working example PR: https://github.com/leiicamundi/keycloak/pull/1