### PR TITLE
chore(gha): disable cleanup triggers due to poc

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -2,16 +2,18 @@
   name: AWS Nightly Cleanup of test regions
 
   on:
-    schedule:
-      - cron: '0 5 * * *'
+    # Temporarily disabled due to the Multi-Region SaaS evaluation
+    # https://github.com/camunda/team-infrastructure-experience/issues/331
+    # schedule:
+      # - cron: '0 5 * * *'
     workflow_dispatch:
       inputs:
         cleanup_older_than:
           description: "Minimum age of the ressources to cleanup"
           default: "12h"
-    pull_request:
-      paths:
-        - .github/workflows/aws_nightly_cleanup.yml
+    # pull_request:
+    #   paths:
+    #     - .github/workflows/aws_nightly_cleanup.yml
 
   env:
     AWS_PROFILE: "infex"


### PR DESCRIPTION
multi-region saas requires both regions, eval takes 2-3 weeks.
I'll see that I do regular cleanups of unrelated / unused resources.