### PR TITLE
feat: add rosa camunda data source

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -115,6 +115,12 @@
       extractVersion: "^v(?<version>.*)$",
     },
   ],
+  "customDatasources": {
+    "rosa-camunda": {
+      "defaultRegistryUrlTemplate": "https://camunda.github.io/camunda-tf-rosa/rosa_versions.txt",
+      "format": "plain",
+    },
+  },
   customManagers: [
    {
       customType: "regex",


### PR DESCRIPTION
tested in https://github.com/leiicamundi/camunda-tf-rosa/pull/10, can be used with `# renovate: datasource=custom.rosa-camunda depName=red-hat-openshift versioning=semver`

related to https://github.com/camunda/team-infrastructure-experience/issues/330