### PR TITLE
fix: global resources only run in one matrix cleanup

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -73,10 +73,17 @@ jobs:
                   --exclude-resource-type s3 \
                   --exclude-resource-type cloudtrail || true
 
-        # Following will delete global resources and things that cloud-nuke does not support
-            - name: Delete additional AWS resources
+        # Following will delete regional resources that cloud-nuke does not support
+            - name: Delete additional regional AWS resources
               timeout-minutes: 15
-              run: .github/workflows/scripts/aws_cleanup.sh "${{ env.AWS_REGION }}"
+              run: .github/workflows/scripts/aws_regional_cleanup.sh "${{ env.AWS_REGION }}"
+
+        # Following will delete global resources that cloud-nuke does not support
+            - name: Delete additional global AWS resources
+              # Only run in a single matrix run
+              if: ${{ env.AWS_REGION == 'eu-west-2' }}
+              timeout-minutes: 15
+              run: .github/workflows/scripts/aws_global_cleanup.sh
 
         # The second run should remove the remaining resources (VPCs) and fail if there's anything left
             - name: Run Cloud Nuke

--- a/.github/workflows/scripts/aws_global_cleanup.sh
+++ b/.github/workflows/scripts/aws_global_cleanup.sh
@@ -4,19 +4,7 @@ set -euxo pipefail
 
 # This script deletes additional AWS resources based on specified criteria.
 
-# Check if the region argument is provided
-if [ -z "$1" ]; then
-    echo "Please provide the AWS region as the first argument."
-    exit 1
-fi
-
-region="$1"
-
-echo "Deleting additional resources in the $region region..."
-
-
-echo "Deleting additional resources..."
-# KMS keys can't be deleted due to resource policies, requires manual intervention
+echo "Deleting additional global resources..."
 
 echo "Deleting IAM Users"
 # Delete Users
@@ -114,30 +102,6 @@ for iam_policy in "${iam_policies_array[@]}"
 do
     echo "Deleting policy: $iam_policy"
     aws iam delete-policy --policy-arn "$iam_policy"
-done
-
-echo "Deleting OIDC Providers"
-# Delete OIDC Provider
-oidc_providers=$(aws iam list-open-id-connect-providers --query "OpenIDConnectProviderList[?contains(Arn, 'eu-west-2') || contains(Arn, 'eu-west-3')].Arn" --output text)
-
-read -r -a oidc_providers_array <<< "$oidc_providers"
-
-for oidc_provider in "${oidc_providers_array[@]}"
-do
-    echo "Deleting OIDC Provider: $oidc_provider"
-    aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "$oidc_provider"
-done
-
-echo "Deleting VPC Peering Connections"
-# Delete VPC Peering Connection
-peering_connection_ids=$(aws ec2 describe-vpc-peering-connections --region "$region" --query "VpcPeeringConnections[?Status.Code == 'active' && Tags[?contains(Value, 'nightly')]]".VpcPeeringConnectionId --output text)
-
-read -r -a peering_connection_ids_array <<< "$peering_connection_ids"
-
-for peering_connection_id in "${peering_connection_ids_array[@]}"
-do
-    echo "Deleting VPC Peering Connection: $peering_connection_id"
-    aws ec2 delete-vpc-peering-connection --region "$region" --vpc-peering-connection-id "$peering_connection_id"
 done
 
 echo "Deleting nightly S3 Buckets"

--- a/.github/workflows/scripts/aws_regional_cleanup.sh
+++ b/.github/workflows/scripts/aws_regional_cleanup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# This script deletes additional AWS resources based on specified criteria.
+
+# Check if the region argument is provided
+if [ -z "$1" ]; then
+    echo "Please provide the AWS region as the first argument."
+    exit 1
+fi
+
+region="$1"
+
+echo "Deleting additional resources in the $region region..."
+
+echo "Deleting OIDC Providers"
+# Delete OIDC Provider
+oidc_providers=$(aws iam list-open-id-connect-providers --query "OpenIDConnectProviderList[?contains(Arn, '$region')].Arn" --output text)
+
+read -r -a oidc_providers_array <<< "$oidc_providers"
+
+for oidc_provider in "${oidc_providers_array[@]}"
+do
+    echo "Deleting OIDC Provider: $oidc_provider"
+    aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "$oidc_provider"
+done
+
+echo "Deleting VPC Peering Connections"
+# Delete VPC Peering Connection
+peering_connection_ids=$(aws ec2 describe-vpc-peering-connections --region "$region" --query "VpcPeeringConnections[?Status.Code == 'active' && Tags[?contains(Value, 'nightly')]]".VpcPeeringConnectionId --output text)
+
+read -r -a peering_connection_ids_array <<< "$peering_connection_ids"
+
+for peering_connection_id in "${peering_connection_ids_array[@]}"
+do
+    echo "Deleting VPC Peering Connection: $peering_connection_id"
+    aws ec2 delete-vpc-peering-connection --region "$region" --vpc-peering-connection-id "$peering_connection_id"
+done


### PR DESCRIPTION
Splits up the regional and global cleanup.
The global cleanup script will be run only in one matrix build.
We could outsource it to another runner, but what for repeating ourselves on the same procedure again?