### PR TITLE
chore(renovate): adjust matchStrings to allow to parse OLD.VERSION fo…

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -133,7 +133,7 @@
         "^justfile$"
         ],
       matchStrings: [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?=(?<currentValue>.*)",
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?=(?:\\s\\.)?(?<currentValue>.*)",
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?- (?<currentValue>.*)",
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?: (?<currentValue>.*)",
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?=\"(?<currentValue>.*)\"",


### PR DESCRIPTION
…r multi-region

related to https://github.com/camunda/team-infrastructure-experience/issues/364

adds the optional parsing for `OLD.version` as an exception in the dual-region setup.

Example from a test repo of mine.
![image](https://github.com/user-attachments/assets/5a7a63f3-2b77-4aff-a920-205dfbdc24ae)
