### PR TITLE
fix: set default value for DRY_RUN

### DIFF
--- a/.github/workflows/scripts/aws_regional_cleanup.sh
+++ b/.github/workflows/scripts/aws_regional_cleanup.sh
@@ -4,6 +4,9 @@ set -euxo pipefail
 
 # This script deletes additional AWS resources based on specified criteria.
 
+# Default value for DRY_RUN is false
+DRY_RUN=false
+
 # Check if the region argument is provided
 if [ -z "$1" ]; then
     echo "Please provide the AWS region as the first argument."


### PR DESCRIPTION
related to https://camunda.slack.com/archives/C076N4G1162/p1729832723460519

`DRY_RUN` wasn't set in one of the scripts and we have pipefail enabled for unset variables.

related run: https://github.com/camunda/infraex-common-config/actions/runs/11513079970/job/32049139658

waiting shortly for it to run through and would go ahead with merging.