### PR TITLE
fix: double timeout minutes for cleanup

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -81,7 +81,7 @@ jobs:
             # We're ignoring ec2_dhcp_option as they couldn't be deleted
             # cloudtrail is managed by IT and can't be deleted either
             - name: Run Cloud Nuke
-              timeout-minutes: 45
+              timeout-minutes: 90
               env:
                   DISABLE_TELEMETRY: 'true'
               run: |
@@ -96,7 +96,7 @@ jobs:
 
             # The second run should remove the remaining resources (VPCs) and fail if there's anything left
             - name: Run Cloud Nuke
-              timeout-minutes: 45
+              timeout-minutes: 90
               env:
                   DISABLE_TELEMETRY: 'true'
               run: |


### PR DESCRIPTION
related to https://camunda.slack.com/archives/C076N4G1162/p1730008108484239

Doubles the timeout time for cloud-nuke.