### PR TITLE
ci: update centralized actionlint to latest version

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -53,7 +53,7 @@ jobs:
               if: env.autofix_pr == 'false'
 
             - name: Centralized Actionlint
-              uses: camunda/infra-global-github-actions/actionlint@2479efb5ed48b2ec0b9cb6db10898fd55c1e9bc5 # main
+              uses: camunda/infra-global-github-actions/actionlint@f9362c30ae191d18ed4d38665a2a010762a02583 # main
 
             - name: Install tooling using asdf
               uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3


### PR DESCRIPTION
Related to: camunda/team-infrastructure#620

The new version adds some sanitization to the `ignore` field to avoid issues with empty or only space lines