### PR TITLE
fix: prevent deleting cloudformation role for wiz connector creation

### DIFF
--- a/.github/workflows/scripts/aws_global_cleanup.sh
+++ b/.github/workflows/scripts/aws_global_cleanup.sh
@@ -14,6 +14,7 @@ SKIP_ROLES=(
   "aws-ec2-spot-fleet-tagging-role*"
   "ref-arch-*"
   "Wiz*"
+  "stacksets-exec-17b1ba2d4b46b1c7ed312b029f146659"
 )
 
 SKIP_POLICIES=(


### PR DESCRIPTION
We need to exclude the cloudformation stacksets role from being deleted, since its needed for cloudformation in the AWS management account to be able to deploy the Wiz connector resources into the account.

Since its a role that gets created automatically when creating the cloudformation stack and not supposed to be deleted, it would need to be created manually this time

![image](https://github.com/user-attachments/assets/857d26ab-fe71-45ff-9201-272a277c8295)


Cloudtrail logs related to the role deletion 

![image](https://github.com/user-attachments/assets/5e6cc727-6dac-48dd-8ecb-039aed9aa26b)

Role creation;

Type: Custom trust policy
Custom trust policy:

`{
    "Version": "2012-10-17",
    "Id": "stacksets-exec-17b1ba2d4b46b1c7ed312b029f146659-assume-role-policy",
    "Statement": [
        {
            "Sid": "1",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::912534604991:role/aws-service-role/stacksets.cloudformation.amazonaws.com/AWSServiceRoleForCloudFormationStackSetsOrgAdmin"
            },
            "Action": "sts:AssumeRole"
        }
    ]
}`

Permissions: AdministratorAccess

Description: Role created by AWSCloudFormation StackSets
Role Name: stacksets-exec-17b1ba2d4b46b1c7ed312b029f146659