### PR TITLE
fix: global pre-commit add additional depdencies

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -56,8 +56,8 @@ jobs:
               uses: camunda/infra-global-github-actions/actionlint@3232e9983af5e05ea446e2cdc3bbaffd4b300e5c # main
 
             # Required for pre-commit to work with Python referenced in .tool-versions for Ubuntu >= 24.04
-            - name: Install SQLite dependency
-              run: sudo apt-get install -y libsqlite3-dev
+            - name: Install Python dependencies
+              run: sudo apt-get install -y libsqlite3-dev libbz2-dev liblzma-dev
 
             - name: Install tooling using asdf
               uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3


### PR DESCRIPTION
tried it out in https://github.com/camunda/camunda-deployment-references/pull/82

seems to fix it, some dependencies missing for shellcheck.