### PR TITLE
feat: add asdf tool cache

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -59,6 +59,17 @@ jobs:
             - name: Install Python dependencies
               run: sudo apt-get install -y libsqlite3-dev libbz2-dev liblzma-dev
 
+            # Setup tool cache
+            - name: Cache asdf installation
+              id: cache
+              uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+              with:
+                  path: |
+                      /home/runner/.asdf
+                  key: ${{ runner.os }}-tooling-${{ hashFiles('**/.tool-versions') }}
+                  restore-keys: |
+                      ${{ runner.os }}-tooling-
+
             - name: Install tooling using asdf
               uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,17 @@ jobs:
             - name: Install SQLite dependency
               run: sudo apt-get install -y libsqlite3-dev
 
+            # Setup tool cache
+            - name: Cache asdf installation
+              id: cache
+              uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+              with:
+                  path: |
+                      /home/runner/.asdf
+                  key: ${{ runner.os }}-tooling-${{ hashFiles('**/.tool-versions') }}
+                  restore-keys: |
+                      ${{ runner.os }}-tooling-
+
             - name: Install tooling using asdf
               uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
 


### PR DESCRIPTION
- adds a cache for asdf installation to speed up e.g. linting.

Example:
- Previous run: https://github.com/camunda/infraex-common-config/actions/runs/12709016291/job/35427159657?pr=163 (creating the cache)
- New run: https://github.com/camunda/infraex-common-config/actions/runs/12709054296/job/35427281995 (restoring the cache)

