### PR TITLE
chore(internal): add a new weekly region

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -50,6 +50,9 @@ jobs:
                     - region: us-east-1
                       day: Saturday
                       cleanup_older_than: 0h
+                    - region: us-east-2
+                      day: Saturday
+                      cleanup_older_than: 0h
 
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To keep the environment organized, all resources in these regions are automatica
 |---------------------|--------------|------------------|
 | EU (Stockholm)      | eu-north-1   | Saturday @5AM    |
 | US East (N. Virginia) | us-east-1 | Saturday @5AM    |
+| US East (Ohio) | us-east-2 | Saturday @5AM    |
 
 #### Permanent Regions
 


### PR DESCRIPTION
For dual region work,  we need two regions that are geographically close to each other, the addition of a new US East provides this proximity.