### PR TITLE
fix(lint-action): strict cache-key with week invalidation

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -60,7 +60,7 @@ jobs:
               run: sudo apt-get install -y libsqlite3-dev libbz2-dev liblzma-dev
 
             - name: Get current week number
-              run: echo "WEEK_NUMBER=$(date +%V)" tee -a "$GITHUB_ENV"
+              run: echo "WEEK_NUMBER=$(date +%V)" | tee -a "$GITHUB_ENV"
 
             # Setup tool cache
             - name: Cache asdf installation


### PR DESCRIPTION
Due to the current cache strategy, we may match cache keys that are outdated. This is what happened in https://github.com/camunda/camunda-deployment-references/actions/runs/12854105129/job/35838054946 for instance.

In order to fix that, I propose to enforce a strict cache key and invalidate the cache on a weekly basis.

@Langleu I'm wondering if our current cache-keys are appropriate (e.g. https://github.com/camunda/keycloak/blob/4bd00a316de99926bcd9e4b0f80918b223ea1e79/.github/workflows/links.yml#L27, perhaps we should introduce kind of a weekly invalidation, wdyt?)