### PR TITLE
fix: global cleanup

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -98,6 +98,14 @@ jobs:
 
                   echo "should_run=$should_run" | tee -a "$GITHUB_ENV"
 
+            # For PR purposes we're overwriting the setting and enable dry run
+            - name: Set DRY_RUN for PR
+              if: github.event_name == 'pull_request'
+              run: |
+                  echo "DRY_RUN=true" | tee -a "$GITHUB_ENV"
+                  echo "CLOUD_NUKE_EXTRA_ARGS=--dry-run" | tee -a "$GITHUB_ENV"
+                  echo "should_run=true" | tee -a "$GITHUB_ENV"
+
             - name: Import Secrets
               id: secrets
               if: ${{ env.should_run == 'true' }}
@@ -170,7 +178,7 @@ jobs:
                   DISABLE_TELEMETRY: 'true'
               if: ${{ env.should_run == 'true' }}
               run: |
-                  ./cloud-nuke_linux_amd64 aws \
+                  ./cloud-nuke_linux_amd64 aws ${{ env.CLOUD_NUKE_EXTRA_ARGS }} \
                   --region ${{ env.AWS_REGION }} \
                   --force \
                   --older-than ${{ env.CLEANUP_OLDER_THAN }} \
@@ -186,7 +194,7 @@ jobs:
                   DISABLE_TELEMETRY: 'true'
               if: ${{ env.should_run == 'true' }}
               run: |
-                  ./cloud-nuke_linux_amd64 aws \
+                  ./cloud-nuke_linux_amd64 aws ${{ env.CLOUD_NUKE_EXTRA_ARGS }} \
                   --region ${{ env.AWS_REGION }} \
                   --force \
                   --older-than ${{ env.CLEANUP_OLDER_THAN }} \

--- a/.github/workflows/scripts/aws_global_cleanup.sh
+++ b/.github/workflows/scripts/aws_global_cleanup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2207
 
 set -euxo pipefail
 
@@ -83,7 +84,7 @@ echo "Deleting IAM Users"
 usernames=$(paginate "aws iam list-users" "Users[].UserName")
 
 if [ -n "$usernames" ]; then
-    read -r -a usernames_array <<< "$usernames"
+    usernames_array=($(echo "$usernames" | tr '\n' ' '))
 
     for username in "${usernames_array[@]}"
     do
@@ -96,7 +97,7 @@ if [ -n "$usernames" ]; then
         attached_policy_arns=$(paginate "aws iam list-attached-user-policies --user-name $username" "AttachedPolicies[].PolicyArn")
 
         if [ -n "$attached_policy_arns" ]; then
-            read -r -a attached_policy_arns_array <<< "$attached_policy_arns"
+            attached_policy_arns_array=($(echo "$attached_policy_arns" | tr '\n' ' '))
             for policy_arn in "${attached_policy_arns_array[@]}"
             do
                 echo "Detaching policy $policy_arn from user $username"
@@ -106,7 +107,7 @@ if [ -n "$usernames" ]; then
 
         inline_policy_names=$(paginate "aws iam list-user-policies --user-name $username" "PolicyNames")
         if [ -n "$inline_policy_names" ]; then
-            read -r -a inline_policy_names_array <<< "$inline_policy_names"
+            inline_policy_names_array=($(echo "$inline_policy_names" | tr '\n' ' '))
             for policy_name in "${inline_policy_names_array[@]}"
             do
                 echo "Deleting inline policy $policy_name from user $username"
@@ -116,7 +117,7 @@ if [ -n "$usernames" ]; then
 
         access_key_ids=$(paginate "aws iam list-access-keys --user-name $username" "AccessKeyMetadata[].AccessKeyId")
         if [ -n "$access_key_ids" ]; then
-            read -r -a access_key_ids_array <<< "$access_key_ids"
+            access_key_ids_array=($(echo "$access_key_ids" | tr '\n' ' '))
             for access_key_id in "${access_key_ids_array[@]}"
             do
                 echo "Deleting access key $access_key_id for user $username"
@@ -134,7 +135,7 @@ echo "Deleting IAM Roles"
 role_arns=$(paginate "aws iam list-roles" "Roles[].RoleName")
 
 if [ -n "$role_arns" ]; then
-    read -r -a role_arns_array <<< "$role_arns"
+    role_arns_array=($(echo "$role_arns" | tr '\n' ' '))
 
     for role_arn in "${role_arns_array[@]}"
     do
@@ -156,7 +157,7 @@ if [ -n "$role_arns" ]; then
         attached_policy_arns=$(paginate "aws iam list-attached-role-policies --role-name $role_arn" "AttachedPolicies[].PolicyArn")
 
         if [ -n "$attached_policy_arns" ]; then
-            read -r -a attached_policy_arns_array <<< "$attached_policy_arns"
+            attached_policy_arns_array=($(echo "$attached_policy_arns" | tr '\n' ' '))
 
             for policy_arn in "${attached_policy_arns_array[@]}"
             do
@@ -167,7 +168,7 @@ if [ -n "$role_arns" ]; then
             policy_arns=$(paginate "aws iam list-role-policies --role-name $role_arn" "PolicyNames")
 
             if [ -n "$policy_arns" ]; then
-                read -r -a policy_arns_array <<< "$policy_arns"
+                policy_arns_array=($(echo "$policy_arns" | tr '\n' ' '))
 
                 for policy_name in "${policy_arns_array[@]}"
                 do
@@ -179,7 +180,7 @@ if [ -n "$role_arns" ]; then
             instance_profile_arns=$(paginate "aws iam list-instance-profiles-for-role --role-name $role_arn" "InstanceProfiles[].InstanceProfileName")
 
             if [ -n "$instance_profile_arns" ]; then
-                read -r -a instance_profile_arns_array <<< "$instance_profile_arns"
+                instance_profile_arns_array=($(echo "$instance_profile_arns" | tr '\n' ' '))
 
                 for instance_profile_arn in "${instance_profile_arns_array[@]}"
                 do
@@ -199,7 +200,7 @@ echo "Deleting IAM Policies"
 iam_policies=$(paginate "aws iam list-policies --scope Local" "Policies[].Arn")
 
 if [ -n "$iam_policies" ]; then
-    read -r -a iam_policies_array <<< "$iam_policies"
+    iam_policies_array=($(echo "$iam_policies" | tr '\n' ' '))
 
     for iam_policy in "${iam_policies_array[@]}"
     do
@@ -232,7 +233,7 @@ echo "Deleting S3 Buckets"
 bucket_ids=$(paginate "aws s3api list-buckets" "Buckets[].Name")
 
 if [ -n "$bucket_ids" ]; then
-    read -r -a buckets <<< "$bucket_ids"
+    buckets=($(echo "$bucket_ids" | tr '\n' ' '))
 
     for bucket in "${buckets[@]}"
     do
@@ -252,7 +253,7 @@ echo "Deleting IAM Identity Providers"
 identity_providers=$(paginate "aws iam list-open-id-connect-providers" "OpenIDConnectProviderList[].Arn")
 
 if [ -n "$identity_providers" ]; then
-    read -r -a identity_providers_array <<< "$identity_providers"
+    identity_providers_array=($(echo "$identity_providers" | tr '\n' ' '))
 
     for provider in "${identity_providers_array[@]}"
     do

--- a/.github/workflows/scripts/aws_regional_cleanup.sh
+++ b/.github/workflows/scripts/aws_regional_cleanup.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 # This script deletes additional AWS resources based on specified criteria.
 
 # Default value for DRY_RUN is false
-DRY_RUN=false
+DRY_RUN=${DRY_RUN:-false}
 
 # Check if the region argument is provided
 if [ -z "$1" ]; then


### PR DESCRIPTION
With `read` it was limited to a 100 items, not sure where the problem exactly stems from. Didn't look into it in detail.
With the alternative, it can process more than 100 items into an array.

I've also added `dry run` as default for PRs, so it runs through everything in dry run and we can see what happens.
Dry run being default also allows us to time it better when it should actually be run and not on every single PR impacting others.