### PR TITLE
fix: add additional updateTypes to schedule

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -58,7 +58,12 @@
     },
     {
       "description": "Only update patch versions on Sundays.",
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": [
+        "lockFileMaintenance",
+        "pin",
+        "digest",
+        "patch"
+      ],
       "schedule": ["* * * * 0"]
     },
     {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-deployment-references/pull/225

it was previously only covering `patches`, so e.g. `digest` could schedule whenever.