### PR TITLE
chore: bump timeout of global cleanup step

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -164,7 +164,7 @@ jobs:
             - name: Delete additional global AWS resources
               # Only run in a single time per week
               if: ${{ env.should_run == 'true' && env.AWS_REGION == 'eu-north-1' }}
-              timeout-minutes: 15
+              timeout-minutes: 45
               env:
                   GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
               run: .github/workflows/scripts/aws_global_cleanup.sh


### PR DESCRIPTION
Related to https://camunda.slack.com/archives/C076N4G1162/p1743830334303069

We apparently had too many IAM resources that to be deleted within 15 minutes. Bumping the timeout.