### PR TITLE
chore: extend regex for helm chart tags

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -184,7 +184,7 @@
     },
     {
       matchPackageNames: ["camunda/camunda-platform-helm"],
-      versioning: "regex:^camunda-platform-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+      versioning: "regex:^camunda-platform(-\\d+\\.\\d+)?-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     }
   ],
   "customDatasources": {


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/614

adjusts the regex for the helm chart to be able to parse both the old and new tag

```
camunda-platform-8.6-11.3.0
camunda-platform-11.3.0
```

Example based on my private repo:

![image](https://github.com/user-attachments/assets/9016c28b-aa08-4a3a-981a-2d41e1ee8b91)

In the case of `stable/x.y` we don't have to add any versioning or so since we only do `minor`, `patch` anyway for the package, so the major one wouldn't be passed along.

Besides that. I haven't fully understood how Renovate deals with the `github-tags` yet, as it found the major but never anything but the latest tag. So I have been unable so far to get a minor or patch release on a `stable` branch of this package. Once I got it to work but afterwards not again, as said not sure how Renovate deals with the tags.

The only workaround I had once was to add the pinned versioning directly to the part it has to update and not have a global versioning for it. Similar to how we have done it in `c8-multi-region` atm.