### PR TITLE
chore: tmp ignore trivy to adress upgrade separately

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -47,6 +47,12 @@
     enabled: true
   },
   packageRules: [
+    // temporarily ignoring trivy updates to stick with 0.60.0
+    // see https://github.com/camunda/team-infrastructure-experience/issues/680
+    {
+      "matchPackageNames": ["aquasecurity/trivy"],
+      "enabled": false
+    },
     {
       "description": "Only update major versions on Fridays outside of business hours.",
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/680

For now ignoring Trivy to deal with the upgrades separately.

From mend:

![image](https://github.com/user-attachments/assets/f84555e1-ec76-4981-8ffa-79a882da65c7)
