### PR TITLE
Fix python issue

### DIFF
--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -91,7 +91,7 @@ runs:
           shell: bash
           run: |
               sudo apt-get update
-              sudo apt-get install liblzma-dev
+              sudo apt-get install liblzma-dev libbz2-dev
 
         - name: Install asdf when no cache hit
           id: install

--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -91,7 +91,7 @@ runs:
           shell: bash
           run: |
               sudo apt-get update
-              sudo apt-get install liblzma-dev libbz2-dev
+              sudo apt-get install liblzma-dev libbz2-dev libreadline-dev
 
         - name: Install asdf when no cache hit
           id: install

--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -162,6 +162,8 @@ runs:
                   exit 1
                 fi
               done
+          env:
+              ASDF_PYTHON_EXTRA_CONFIGURE_OPTIONS: --with-lzma
 
         - name: Cache installed tools
           id: cache-tools

--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -84,6 +84,15 @@ runs:
               # invalidate the cache every week as we might need dependencies of the packages
               key: ${{ steps.cache-key.outputs.cache_key }}
 
+        # Some ASDF packages require Python to be compiled with lzma support
+        # including e.g. azure cli
+        - name: Install library preqrequisites
+          if: ${{ inputs.cache == 'false' || steps.cache-asdf-check.outputs.cache-hit != 'true' }}
+          shell: bash
+          run: |
+              sudo apt-get update
+              sudo apt-get install liblzma-dev
+
         - name: Install asdf when no cache hit
           id: install
           shell: bash


### PR DESCRIPTION
shellcheck has had problems with the python installation missing zlma, similar to azure cli (which we postponed atm).
I'm using the same fix locally to properly compile python with the library, same problem with shellcheck.