### PR TITLE
feat(renovate): handles custom openshift acm datasource

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -242,7 +242,7 @@
       ],
       extractVersion: '^(?<version>.*)-eks.+$',
     },
-      {
+    {
       // The versioning is a bit strange, so we need to help a bit with parsing it correctly
       matchPackageNames: [
         'amazon/cloudwatch-agent',
@@ -254,20 +254,6 @@
         'camunda/camunda-platform-helm',
       ],
       versioning: 'regex:^camunda-platform(-\\d+\\.\\d+)?-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
-    },
-    {
-      description: 'Update ACM Subscription channel using custom.openshift-acm',
-      matchDatasources: [
-        'custom.openshift-acm',
-      ],
-      matchManagers: [
-        'custom.regex',
-      ],
-      matchStrings: [
-        'channel:\\s*release-(?<currentValue>\\d+\\.\\d+)',
-      ],
-      extractVersion: '^release-(?<version>\\d+\\.\\d+)$',
-      versioning: 'major.minor',
     },
   ],
   'customDatasources': {
@@ -297,6 +283,7 @@
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?=(?:\\s\\.)?(?<currentValue>.*)',
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?- (?<currentValue>.*)',
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?: (?<currentValue>.*)',
+        'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?: release-(?<currentValue>.*)',
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?="(?<currentValue>.*)"',
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?-"(?<currentValue>.*)"',
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*? "(?<currentValue>.*)"',


### PR DESCRIPTION
This PR:
- update the renovate config to follow the suggested new format (https://github.com/leiicamundi/test-renovate/pull/2/files)
- introduces red hat openshift acm custom source and associated capture manager:

```json
  'customDatasources': {
    'rosa-camunda': {
      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/rosa_versions.txt',
      'format': 'plain',
    },
    'openshift-acm': {
      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/openshift_acm_versions.txt',
      'format': 'plain',
    },
    
    # the following has been added in customManagers
            'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?: release-(?<currentValue>.*)',
```

Regarding the extension of customManagers, I've not found a more elegant way to catpure the release- prefix

This configuration has been tested in this repo https://github.com/leiicamundi/test-renovate/pull/4/files

I'll create 2 PRs in the ref arch repo, this PR is a follow up of https://github.com/camunda/camunda-deployment-references/pull/366 to get it automated

The source is updated in https://github.com/camunda/camunda-deployment-references/pull/367