### PR TITLE
chore(deps): update pre-commit hook renovatebot/pre-commit-hooks to v40

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
           - id: actionlint
 
     - repo: https://github.com/renovatebot/pre-commit-hooks
-      rev: 39.259.0
+      rev: 40.3.2
       hooks:
           - id: renovate-config-validator
             args: [--strict]
             # TODO : revert this when https://github.com/renovatebot/pre-commit-hooks/issues/2460 is fixed
-            language_version: 20.18.0
+            language_version: lts
 
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
       rev: 0.2.3

--- a/default.json5
+++ b/default.json5
@@ -267,18 +267,18 @@
     },
   },
   customManagers: [
-   {
+    {
       customType: 'regex',
-      fileMatch: [
-        '.yaml$',
-        '.yml$',
-        '.sh$',
-        '.go$',
-        '.tf$',
-        '.tfvars$',
-        '.tool-versions$',
-        '^justfile$',
-        ],
+      managerFilePatterns: [
+        '/\\.yaml$/',
+        '/\\.yml$/',
+        '/\\.sh$/',
+        '/\\.go$/',
+        '/\\.tf$/',
+        '/\\.tfvars$/',
+        '/\\.tool-versions$/',
+        '/^justfile$/',
+      ],
       matchStrings: [
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?=(?:\\s\\.)?(?<currentValue>.*)',
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?- (?<currentValue>.*)',


### PR DESCRIPTION
Reverts camunda/infraex-common-config#242

Renovate has finally updated their public instance to the latest version.
Checked on a private repo, was working properly now.