### PR TITLE
fix: todo checker branch

### DIFF
--- a/.github/workflows/todo-checker-global.yml
+++ b/.github/workflows/todo-checker-global.yml
@@ -6,7 +6,6 @@ name: todo-checker-global
 # This helps ensure TODOs are not forgotten or left unintentionally in production code.
 #
 # If a TODO is no longer relevant or needs no further reminders, reacting with 👎 on the comment suppresses future alerts.
-# Developers can trigger a manual refresh by commenting `update todos` on the PR.
 #
 # This workflow is designed to be used across multiple repositories via `workflow_call` (see `todo-checker.yml`).
 
@@ -160,7 +159,7 @@ jobs:
                       <br> TODO: \`$TEXT\`
                       <br>**🔕 React with 👎 (thumbs down) to this comment to acknowledge and prevent further reminders.**
                       <br>
-                      Comment with \`update todos\` in the main thread or <a href=\"$WORKFLOW_URL\" target=\"_blank\">click here to retry and refresh the list of remaining TODOs</a>"
+                      <a href=\"$WORKFLOW_URL\" target=\"_blank\">Click here to retry and refresh the list of remaining TODOs</a>"
 
                       echo "💬 Commenting on $FILE:$LINE"
                       gh api \

--- a/.github/workflows/todo-checker.yml
+++ b/.github/workflows/todo-checker.yml
@@ -7,8 +7,6 @@ name: Check TODOs via global workflow
 
 
 on:
-    issue_comment:
-        types: [created, edited]
     pull_request:
         types: [opened, synchronize, reopened]
 
@@ -18,9 +16,5 @@ concurrency:
 
 jobs:
     call-todo-checker:
-        if: |
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'issue_comment' &&
-            contains(github.event.comment.body, 'update todos'))
         uses: ./.github/workflows/todo-checker-global.yml
         secrets: inherit


### PR DESCRIPTION
@Langleu FYI, I'm merging this fix:
- Removes the issue_comment event, it's too complicated to capture the origin of the PR based on the comment event
- Fix the comparaison to be done on the target branch instead of the hardcoded main branch