### PR TITLE
fix: use hard-coded schedule of lockFileMaintenance

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -43,6 +43,7 @@
     addLabels: ['security'], // Security alerts should be handled manually to assess the consequences.
     enabled: true,
   },
+  // Runs every Monday before 4 am, hard-coded by Renovate
   lockFileMaintenance: {
     enabled: true,
   },
@@ -76,7 +77,6 @@
     {
       description: 'Only update patch versions on Sundays.',
       matchUpdateTypes: [
-        'lockFileMaintenance',
         'pin',
         'digest',
         'patch',


### PR DESCRIPTION
Based on a slack request.
@leiicamundi notices that lock file maintenance isn't happening.

The reasoning is likely conflicting schedules.
Based on the [Renovate docs](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)

> To reduce "noise" in the repository, Renovate performs lockFileMaintenance "before 4am on monday", i.e. to achieve once-per-week semantics. Depending on its running schedule, Renovate may run a few times within that time window - even possibly updating the lock file more than once - but it hopefully leaves enough time for tests to run and automerge to apply, if configured.


We have only allowed it run on sundays so it never scheduled it since Renovate hard coded it to before 4 am on Mondays.