### PR TITLE
tmp disable cleanup in eu-north-1

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -44,9 +44,10 @@ jobs:
                     - region: eu-west-3
                       day: All
                       cleanup_older_than: 12h
-                    - region: eu-north-1
-                      day: Saturday
-                      cleanup_older_than: 0h
+                    # TODO: revert when https://camunda.slack.com/archives/C08QY4SREGY is solved
+                    # - region: eu-north-1
+                    #   day: Saturday
+                    #   cleanup_older_than: 0h
                     - region: us-east-1
                       day: Saturday
                       cleanup_older_than: 0h


### PR DESCRIPTION
due to replication of customer infra, I would like to disable temporarly the weekly cleanup of this region