### PR TITLE
fix: ignore base commit contents

### DIFF
--- a/.github/workflows/todo-checker-global.yml
+++ b/.github/workflows/todo-checker-global.yml
@@ -118,7 +118,11 @@ jobs:
                     # Check if blamed_commit is strictly inside PR commits:
                     # 1) BASE_SHA is ancestor of blamed_commit (blamed_commit is after base)
                     # 2) blamed_commit is ancestor of HEAD_SHA (blamed_commit is in PR branch history)
-                    if git merge-base --is-ancestor "$BASE_SHA" "$blamed_commit" && git merge-base --is-ancestor "$blamed_commit" "$HEAD_SHA"; then
+                    # 3) blamed_commit is not the same as BASE_SHA (exclude base commits)
+                    if [ "$blamed_commit" = "$BASE_SHA" ]; then
+                      echo "⏭️ $FILE:$LINE ignored, blamed_commit is the base commit ($blamed_commit)"
+                      continue
+                    elif git merge-base --is-ancestor "$BASE_SHA" "$blamed_commit" && git merge-base --is-ancestor "$blamed_commit" "$HEAD_SHA"; then
                       echo "✅ $FILE:$LINE is strictly part of the PR (commit $blamed_commit)"
                     else
                       echo "⏭️ $FILE:$LINE ignored, blamed_commit $blamed_commit not strictly in PR"


### PR DESCRIPTION
if there is a todo in the base then it is causing issues with the diff as its interpreted as coming from the PR

Failing TODO checker as the file doesn't actually exist in the PR:
https://github.com/camunda/camunda-deployment-references/actions/runs/16497462931/job/46646631278?pr=768

Run that fixes the issue:
https://github.com/camunda/camunda-deployment-references/actions/runs/16497885298/job/46648095759?pr=769

I'll go ahead and merge it, so we don't have those issues anymore.