### PR TITLE
hackdays: add gha failure log anaylzer with chatgpt

### DIFF
--- a/.github/actions/gha-failure-log-analyzer/README.md
+++ b/.github/actions/gha-failure-log-analyzer/README.md
@@ -1,0 +1,78 @@
+# GHA Failure Log Analyzer
+
+## Description
+
+Analyzes GitHub Actions failure logs and posts results to a Slack thread.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `run_url` | <p>GitHub Actions run URL to analyze</p> | `true` | `""` |
+| `slack_thread_ts` | <p>Slack thread ts to post the analysis result</p> | `false` | `""` |
+| `slack_channel_id` | <p>Slack channel ID to post the analysis result</p> | `false` | `""` |
+| `slack_token` | <p>Slack Token for posting messages</p> | `false` | `""` |
+| `gh_token` | <p>GitHub Token for authentication</p> | `true` | `""` |
+| `max_tokens` | <p>Maximum tokens for AI model response</p> | `false` | `600` |
+| `model` | <p>AI model to use for analysis</p> | `false` | `openai/gpt-4o` |
+
+
+## Outputs
+
+| name | description |
+| --- | --- |
+| `response` | <p>AI analysis response</p> |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/infraex-common-config/.github/actions/gha-failure-log-analyzer@main
+  with:
+    run_url:
+    # GitHub Actions run URL to analyze
+    #
+    # Required: true
+    # Default: ""
+
+    slack_thread_ts:
+    # Slack thread ts to post the analysis result
+    #
+    # Required: false
+    # Default: ""
+
+    slack_channel_id:
+    # Slack channel ID to post the analysis result
+    #
+    # Required: false
+    # Default: ""
+
+    slack_token:
+    # Slack Token for posting messages
+    #
+    # Required: false
+    # Default: ""
+
+    gh_token:
+    # GitHub Token for authentication
+    #
+    # Required: true
+    # Default: ""
+
+    max_tokens:
+    # Maximum tokens for AI model response
+    #
+    # Required: false
+    # Default: 600
+
+    model:
+    # AI model to use for analysis
+    #
+    # Required: false
+    # Default: openai/gpt-4o
+```

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -1,0 +1,149 @@
+---
+name: GHA Failure Log Analyzer
+description: |
+    Analyzes GitHub Actions failure logs and posts results to a Slack thread.
+
+inputs:
+    run_url:
+        description: GitHub Actions run URL to analyze
+        required: true
+    slack_thread_ts:
+        description: Slack thread ts to post the analysis result
+        required: false
+    slack_channel_id:
+        description: Slack channel ID to post the analysis result
+        required: false
+    slack_token:
+        description: Slack Token for posting messages
+        required: false
+    gh_token:
+        description: GitHub Token for authentication
+        required: true
+    max_tokens:
+        description: Maximum tokens for AI model response
+        required: false
+        default: '600'
+    model:
+        description: AI model to use for analysis
+        required: false
+        default: openai/gpt-4o
+
+outputs:
+    response:
+        description: AI analysis response
+        value: ${{ steps.analyze.outputs.response }}
+
+runs:
+    using: composite
+    steps:
+        - name: Parse GitHub Actions URL
+          shell: bash
+          id: parse-url
+          run: |
+              # Extract owner, repo, and run_id from the URL
+              # Expected format: https://github.com/owner/repo/actions/runs/run_id
+              url="${{ inputs.run_url }}"
+
+              if [[ ! "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/actions/runs/([0-9]+) ]]; then
+                echo "Error: Invalid GitHub Actions URL format"
+                echo "Expected format: https://github.com/owner/repo/actions/runs/run_id"
+                exit 1
+              fi
+
+              owner="${BASH_REMATCH[1]}"
+              repo="${BASH_REMATCH[2]}"
+              run_id="${BASH_REMATCH[3]}"
+
+              echo "owner=$owner" >> $GITHUB_OUTPUT
+              echo "repo=$repo" >> $GITHUB_OUTPUT
+              echo "run_id=$run_id" >> $GITHUB_OUTPUT
+
+              echo "Parsed URL:"
+              echo "  Owner: $owner"
+              echo "  Repository: $repo"
+              echo "  Run ID: $run_id"
+
+        - name: Fetch GitHub Actions Logs
+          shell: bash
+          id: fetch-logs
+          run: |
+              # Download logs using GitHub CLI
+              echo "Fetching logs for run ${{ steps.parse-url.outputs.run_id }} from ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }}"
+
+              # Create logs directory
+              mkdir -p logs
+
+              gh run view ${{ steps.parse-url.outputs.run_id }} \
+                --repo ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }} \
+                --log-failed > logs/failed.log
+
+              echo "removing timestamps and downsizing logs"
+              sed -E 's/.*[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z[[:space:]]*//' logs/failed.log > logs/trimmed.log
+              echo "Filtering logs for errors, failures, and exceptions"
+              cat logs/trimmed.log | grep -iC 5 -E 'error|fail|exception' > logs/errors.log
+              echo "Downsizing log file to 50KB"
+              head -c 51200 logs/errors.log > logs/trimmed_50kb.log
+
+              echo "Listing logs directory contents:"
+              ls -lh logs
+
+              LOG_CONTENT="$(cat logs/trimmed_50kb.log | tr -d '\n')"
+              echo "Downsized log file size: $(echo "$LOG_CONTENT" | wc -l) lines"
+              echo "log-file=$LOG_CONTENT" >> "$GITHUB_OUTPUT"
+          env:
+              GH_TOKEN: ${{ inputs.gh_token }}
+
+        - name: Analyze Logs with AI
+          id: analyze
+          uses: actions/ai-inference@b81b2afb8390ee6839b494a404766bef6493c7d9 # v1.2.8
+          with:
+              model: ${{ inputs.model }}
+              max-tokens: ${{ inputs.max_tokens }}
+              prompt: |
+                  You are an expert GitHub Actions troubleshooting assistant. Please analyze the following GitHub Actions workflow logs and provide:
+
+                  1. **Issues Found**: Any errors, failures, or problems identified
+                  2. **Root Cause Analysis**: If there are failures, identify the likely root causes
+                  3. **Recommendations**: Specific actionable steps to fix any issues
+                  4. **Best Practices**: Any suggestions for improving the workflow
+
+                  Please be concise but thorough in your analysis. Focus on actionable insights.
+                  For the markdown output you are only allowed to use the following:
+                    bold *text*
+                    italic _text_
+                    strikethrough ~text~
+                    code `text`
+                    blockquote > text
+                    code block with triple backticks ```text```
+                    ordered list 1. item
+                    unordered list - item
+                    links [text](url)
+                  Under no circumstances use double asterisks for bold text, it's single asterisks only.
+                  Under no circumstances try to wrap the whole output in a code block.
+
+                  Here are the logs to analyze:
+
+                  ${{ steps.fetch-logs.outputs.log-file }}
+        - name: Post Analysis Result
+          if: ${{ inputs.slack_thread_ts != '' }}
+          uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+          with:
+              method: chat.postMessage
+              token: ${{ inputs.slack_token }}
+              payload: |
+                  {
+                    "channel": "${{ inputs.slack_channel_id }}",
+                    "text": "GitHub Actions Analysis Result",
+                    "thread_ts": "${{ inputs.slack_thread_ts }}",
+                    "icon_emoji": ":robot_face:",
+                    "username": "GitHub Actions Analyzer",
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ${{ toJSON(steps.analyze.outputs.response) }}
+                        }
+                      }
+                    ]
+                  }

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -63,6 +63,16 @@ runs:
               echo "  Repository: $repo"
               echo "  Run ID: $run_id"
 
+        - name: Wait for worfklow run to finish
+          shell: bash
+          run: |
+              echo "Waiting for the workflow run to complete ..."
+              gh run watch "${RUN_ID}"
+          env:
+              GH_REPO: ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }}
+              GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+              RUN_ID: ${{ steps.parse-url.outputs.run_id }}
+
         - name: Fetch GitHub Actions Logs
           shell: bash
           id: fetch-logs

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -109,6 +109,7 @@ runs:
           with:
               model: ${{ inputs.model }}
               max-tokens: ${{ inputs.max_tokens }}
+              token: ${{ inputs.gh_token }}
               prompt: |
                   You are an expert GitHub Actions troubleshooting assistant. Please analyze the following GitHub Actions workflow logs and provide:
 

--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -107,3 +107,20 @@ runs:
                   }
           env:
               WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+        - name: Trigger GHA Failure Log Analyzer
+          id: trigger-analyzer
+          if: ${{ steps.silence-check.outcome != 'success' }} # in case of success it means that a silence issue exists
+          shell: bash
+          run: |
+              echo "Triggering GHA Failure Log Analyzer workflow..."
+              gh workflow run "GHA Failure Log Analyzer" \
+                --repo camunda/infraex-common-config \
+                --field run_url="${{ env.WORKFLOW_URL }}" \
+                --field slack_channel_id="${{ inputs.slack_channel_id }}" \
+                --field slack_thread_ts="${{ steps.slack-notification.outputs.ts }}"
+
+              echo "GHA Failure Log Analyzer triggered successfully"
+          env:
+              GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+              WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/gha-failure-log-analyzer.yml
+++ b/.github/workflows/gha-failure-log-analyzer.yml
@@ -1,0 +1,66 @@
+---
+name: GitHub Actions Analyzer
+
+on:
+    workflow_dispatch:
+        inputs:
+            run_url:
+                description: GitHub Actions run URL to analyze
+                required: true
+                type: string
+            slack_channel_id:
+                description: Slack channel ID to post the analysis result
+                required: false
+                type: string
+                default: C07E4FF6YMB
+            slack_thread_ts:
+                description: Slack thread ts to post the analysis result
+                required: false
+                type: string
+
+jobs:
+    analyze-logs:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            actions: read
+            models: read
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - name: Generate token for GitHub
+              id: generate-github-token
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@16a58ec264aba7d6f610b93dea782995d4f16963 # main
+              with:
+                  github-app-id-vault-key: GITHUB_APP_ID
+                  github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common
+                  github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
+                  github-app-private-key-vault-path: secret/data/products/infrastructure-experience/ci/common
+                  vault-auth-method: approle
+                  vault-auth-role-id: ${{ secrets.vault_role_id }}
+                  vault-auth-secret-id: ${{ secrets.vault_secret_id }}
+                  vault-url: ${{ secrets.vault_addr }}
+            - name: Import Secrets
+              id: secrets
+              uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
+              with:
+                  url: ${{ secrets.vault_addr }}
+                  method: approle
+                  roleId: ${{ secrets.vault_role_id }}
+                  secretId: ${{ secrets.vault_secret_id }}
+                  exportEnv: false
+                  secrets: |
+                      secret/data/products/infrastructure-experience/ci/common SLACK_BOT_TOKEN;
+            - name: GHA Failure Log Analyzer
+              id: analyze-logs
+              uses: ./.github/workflows/actions/gha-failure-log-analyzer
+              with:
+                  run_url: ${{ github.event.inputs.run_url }}
+                  slack_thread_ts: ${{ github.event.inputs.slack_thread_ts }}
+                  slack_channel_id: ${{ github.event.inputs.slack_channel_id }}
+                  gh_token: ${{ steps.generate-github-token.outputs.token }}
+                  slack_token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+            - name: Set Results as step output
+              id: set-output
+              run: echo "${{ steps.analyze-logs.outputs.response }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/gha-failure-log-analyzer.yml
+++ b/.github/workflows/gha-failure-log-analyzer.yml
@@ -1,5 +1,5 @@
 ---
-name: GitHub Actions Analyzer
+name: GHA Failure Log Analyzer
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
This idea will add a workflow and action (in case someone wants to just use the action itself) and based on our slack failure output action add to the thread automatically a first assessment for the medic.

It's just an idea.
I'll likely still have to iterate a bit on the prompt as so far the output is a bit meh for slack.

The idea was to keep it lightweight so we can worst case just throw it away / out again without being super intervined with our system.
It could later be extended to add more context from slack itself by older alerts but that's for another day.

Linting will fail as actionlint was last updated 7 months ago by the maintainer and the models permissions stuff was added a month ago. There's also currently no way that I know of to ignore the error.