### PR TITLE
chore: tmp switch to forked actionlint

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -52,8 +52,9 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
               if: env.autofix_pr == 'false'
 
-            - name: Centralized Actionlint
-              uses: camunda/infra-global-github-actions/actionlint@4c0c3611b80ac8e147f7991092a0e282b52c48fa # main
+            # TODO: Renable when switching back to upstream actionlint
+            # - name: Centralized Actionlint
+            #   uses: camunda/infra-global-github-actions/actionlint@4c0c3611b80ac8e147f7991092a0e282b52c48fa # main
 
             # Required for pre-commit to work with Python referenced in .tool-versions for Ubuntu >= 24.04
             - name: Install Python dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
           - id: end-of-file-fixer
           - id: check-added-large-files
 
-    - repo: https://github.com/rhysd/actionlint
-      rev: v1.7.7
+    - repo: https://github.com/mattleibow/actionlint
+      rev: 7b6f502befda0d99dcb5a1cf8cf72d792bfa7c8a
       hooks:
           - id: actionlint
             args: [-ignore=SC2155]


### PR DESCRIPTION
I'm temporarily switching to the forked actionlint that has the models change included, so we won't have issues here.
I'm subscribed to the upstream issue and PR in case it should move forward and also have reached out to the maintainer.