### PR TITLE
fix: permission issue for analyzer trigger

### DIFF
--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -46,6 +46,9 @@ runs:
               vault-auth-role-id: ${{ inputs.vault_role_id }}
               vault-auth-secret-id: ${{ inputs.vault_secret_id }}
               vault-url: ${{ inputs.vault_addr }}
+              # we generate a token with access to all assigned repos for the analyzer trigger
+              owner: camunda
+              repositories: '!all'
 
         - name: Check for Silence Issue
           id: silence-check


### PR DESCRIPTION
> Triggering GHA Failure Log Analyzer workflow...
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/camunda/infraex-common-config/actions/workflows/181037806/dispatches)

The problem was or is that the token was only ever created for the calling repository, which would only have permissions within that as it made sense before. But now we're calling a central workflow in a different repo.
Therefore, I'm extending the token create to cover all assigned repos, which are just our infraex repos (checked it before).
