### PR TITLE
fix(renovate): allow AKS/EKS minor updates on stable branches

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -123,6 +123,20 @@
       enabled: true,
     },
     {
+      description: 'Allow minor releases of azure-kubernetes-service and amazon-eks on maintenance branches (AKS/EKS versions only have major.minor, so every update is a minor bump).',
+      matchPackageNames: [
+        'azure-kubernetes-service',
+        'amazon-eks',
+      ],
+      matchBaseBranches: [
+        '/^stable\\/8\\..*/',
+      ],
+      matchUpdateTypes: [
+        'minor',
+      ],
+      enabled: true,
+    },
+    {
       groupName: 'minor-grouped',
       matchUpdateTypes: [
         'minor',


### PR DESCRIPTION
## Summary
- AKS and EKS versions only have `major.minor` components (e.g., `1.32` → `1.34`), so Renovate classifies every version change as a **minor** bump
- The existing rule disabling minor+major updates on `stable/8.*` branches was unintentionally blocking all Kubernetes version updates for these packages
- Adds an exception rule (matching the existing `camunda-platform` pattern) to re-enable minor updates for `azure-kubernetes-service` and `amazon-eks`

## Test plan
- [ ] Verify Renovate config validation passes in CI (`pre-commit run --all-files`)
- [ ] Confirm Renovate creates PRs for AKS/EKS minor updates on a `stable/8.*` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)