### PR TITLE
fix: update permanent resources

### DIFF
--- a/.github/config/permanent_resources_allowlist.yml
+++ b/.github/config/permanent_resources_allowlist.yml
@@ -39,7 +39,7 @@ aws:
         guard-duty:
             - bcca476a1af978e0790122c5bc643db6
         # KMS keys
-        kmscustomerkeys:
+        kms-customer-key:
             - wizKey
             - ef599a48-c880-442f-a0bf-f9876009e47e # wizKey (cloud-nuke reports key ID instead of alias)
         # CloudFormation StackSets
@@ -51,7 +51,7 @@ aws:
         # GuardDuty
         guard-duty:
             - 44ca476c1446ecf0ebf8ceeab186aed4
-        kmscustomerkeys:
+        kms-customer-key:
             - wizKey
             - 9d765405-e023-4624-81cc-08eb1b7558c4 # wizKey (cloud-nuke reports key ID instead of alias)
         cloudformation-stack:

--- a/.github/config/permanent_resources_allowlist.yml
+++ b/.github/config/permanent_resources_allowlist.yml
@@ -35,6 +35,9 @@ aws:
         # Security Hub
         security-hub:
             - arn:aws:securityhub:*:*:hub/default
+        # GuardDuty
+        guard-duty:
+            - bcca476a1af978e0790122c5bc643db6
         # KMS keys
         kmscustomerkeys:
             - wizKey
@@ -45,6 +48,9 @@ aws:
             - StackSet-Wiz-*
 
     eu-west-1:
+        # GuardDuty
+        guard-duty:
+            - 44ca476c1446ecf0ebf8ceeab186aed4
         kmscustomerkeys:
             - wizKey
             - 9d765405-e023-4624-81cc-08eb1b7558c4 # wizKey (cloud-nuke reports key ID instead of alias)


### PR DESCRIPTION
Related to https://camunda.slack.com/archives/C076N4G1162/p1776636819028229

This pull request updates the `.github/config/permanent_resources_allowlist.yml` file to improve the organization and coverage of AWS resource allowlists. The main changes add GuardDuty detector IDs to the allowlist and standardize the naming of KMS customer keys.

**Resource allowlist updates:**

* Added a new `guard-duty` section with specific detector IDs for both the default and `eu-west-1` AWS regions. [[1]](diffhunk://#diff-4dc8d9d06b95de5e6092c505f3a4a817a5773ba3723de3e20b22a0ec72da9835R38-R42) [[2]](diffhunk://#diff-4dc8d9d06b95de5e6092c505f3a4a817a5773ba3723de3e20b22a0ec72da9835L48-R54)

**Naming standardization:**

* Renamed the `kmscustomerkeys` section to `kms-customer-key` for better consistency and clarity. [[1]](diffhunk://#diff-4dc8d9d06b95de5e6092c505f3a4a817a5773ba3723de3e20b22a0ec72da9835R38-R42) [[2]](diffhunk://#diff-4dc8d9d06b95de5e6092c505f3a4a817a5773ba3723de3e20b22a0ec72da9835L48-R54)