### PR TITLE
ci(aws-cleanup): tolerate Cloud Nuke timeout on first pass

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -170,12 +170,12 @@ jobs:
                   GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
               run: .github/workflows/scripts/aws_global_cleanup.sh
 
-            # This is likely to fail, therefore we ignore the error
-            # (timeout-minutes would otherwise fail the job despite `|| true`,
-            # so we also set continue-on-error to truly tolerate timeouts here)
+            # This is likely to fail, therefore we ignore the error via
+            # `continue-on-error: true` (which also covers timeout-minutes
+            # killing the step, unlike a shell-level `|| true`).
             # We're ignoring ec2-dhcp-option as they couldn't be deleted
             # cloudtrail is managed by IT and can't be deleted either
-            - name: Run Cloud Nuke
+            - name: Run Cloud Nuke (best-effort)
               timeout-minutes: 90
               continue-on-error: true
               env:
@@ -190,10 +190,10 @@ jobs:
                   --exclude-resource-type ec2-keypairs \
                   --exclude-resource-type guard-duty \
                   --exclude-resource-type s3 \
-                  --exclude-resource-type cloudtrail || true
+                  --exclude-resource-type cloudtrail
 
             # The second run should remove the remaining resources (VPCs) and fail if there's anything left
-            - name: Run Cloud Nuke
+            - name: Run Cloud Nuke (strict)
               timeout-minutes: 90
               env:
                   DISABLE_TELEMETRY: 'true'

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -171,10 +171,13 @@ jobs:
               run: .github/workflows/scripts/aws_global_cleanup.sh
 
             # This is likely to fail, therefore we ignore the error
+            # (timeout-minutes would otherwise fail the job despite `|| true`,
+            # so we also set continue-on-error to truly tolerate timeouts here)
             # We're ignoring ec2-dhcp-option as they couldn't be deleted
             # cloudtrail is managed by IT and can't be deleted either
             - name: Run Cloud Nuke
               timeout-minutes: 90
+              continue-on-error: true
               env:
                   DISABLE_TELEMETRY: 'true'
               if: ${{ env.should_run == 'true' }}


### PR DESCRIPTION
The first 'Run Cloud Nuke' step is a best-effort cleanup that uses '|| true' to ignore non-zero exits. However, GitHub Actions' timeout-minutes kills the step with a status that bypasses the shell redirection, failing the whole job (as seen with a 90 min timeout during EBS deletion in eu-west-2).

Add 'continue-on-error: true' so the first pass truly tolerates timeouts. The second 'Run Cloud Nuke' step remains strict and is the one that validates the cleanup result.