### PR TITLE
feat(report-failure-on-slack): add branch-aware severity and richer alert context

### DIFF
--- a/.github/actions/report-failure-on-slack/README.md
+++ b/.github/actions/report-failure-on-slack/README.md
@@ -17,7 +17,7 @@ Use it with `if: failure()`
 | `slack_channel_id` | <p>The Slack channel ID where the notification will be sent.</p> | `false` | `C076N4G1162` |
 | `slack_mention_people` | <p>The Slack people to mention in the notification.</p> | `false` | `@infraex-medic` |
 | `disable_silence_check` | <p>Disable silence check. By default, alerts can be disabled by creating an issue in the repository with the label alert-management and with the title: silence: name of your workflow</p> | `false` | `false` |
-| `branch` | <p>The branch the workflow is testing. Used to add severity context to the Slack alert. Defaults to auto-detection: github.base<em>ref for PRs (target branch), github.ref</em>name for push/schedule events. Alerts on stable/* branches include a prominent severity marker.</p> | `false` | `""` |
+| `branch` | <p>The branch the workflow is testing. Used to add severity context to the Slack alert. Defaults to auto-detection: <code>github.base_ref</code> for PRs (target branch), <code>github.ref_name</code> for push/schedule events. Alerts on <code>stable/*</code> branches include a prominent severity marker.</p> | `false` | `""` |
 
 
 ## Runs
@@ -70,8 +70,9 @@ This action is a `composite` action.
 
     branch:
     # The branch the workflow is testing. Used to add severity context to the Slack alert.
-    # Defaults to auto-detection: github.base_ref for PRs (target branch), github.ref_name for push/schedule events.
-    # Alerts on stable/* branches include a prominent severity marker.
+    # Defaults to auto-detection: `github.base_ref` for PRs (target branch),
+    # `github.ref_name` for push/schedule events.
+    # Alerts on `stable/*` branches include a prominent severity marker.
     #
     # Required: false
     # Default: ""

--- a/.github/actions/report-failure-on-slack/README.md
+++ b/.github/actions/report-failure-on-slack/README.md
@@ -17,6 +17,7 @@ Use it with `if: failure()`
 | `slack_channel_id` | <p>The Slack channel ID where the notification will be sent.</p> | `false` | `C076N4G1162` |
 | `slack_mention_people` | <p>The Slack people to mention in the notification.</p> | `false` | `@infraex-medic` |
 | `disable_silence_check` | <p>Disable silence check. By default, alerts can be disabled by creating an issue in the repository with the label alert-management and with the title: silence: name of your workflow</p> | `false` | `false` |
+| `branch` | <p>The branch the workflow is testing. Used to add severity context to the Slack alert. Defaults to auto-detection: github.base<em>ref for PRs (target branch), github.ref</em>name for push/schedule events. Alerts on stable/* branches include a prominent severity marker.</p> | `false` | `""` |
 
 
 ## Runs
@@ -66,4 +67,12 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: false
+
+    branch:
+    # The branch the workflow is testing. Used to add severity context to the Slack alert.
+    # Defaults to auto-detection: github.base_ref for PRs (target branch), github.ref_name for push/schedule events.
+    # Alerts on stable/* branches include a prominent severity marker.
+    #
+    # Required: false
+    # Default: ""
 ```

--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -29,6 +29,13 @@ inputs:
             silence: name of your workflow
         required: false
         default: 'false'
+    branch:
+        description: |
+            The branch the workflow is testing. Used to add severity context to the Slack alert.
+            Defaults to auto-detection: github.base_ref for PRs (target branch), github.ref_name for push/schedule events.
+            Alerts on stable/* branches include a prominent severity marker.
+        required: false
+        default: ''
 
 runs:
     using: composite
@@ -72,6 +79,33 @@ runs:
           env:
               GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
 
+        - name: Prepare notification context
+          id: context
+          if: ${{ steps.silence-check.outcome != 'success' }} # in case of success it means that a silence issue exists
+          shell: bash
+          run: |
+              # Resolve branch: explicit input > PR base ref (target branch) > current ref
+              BRANCH="${{ inputs.branch }}"
+              if [[ -z "$BRANCH" ]]; then
+                BRANCH="${{ github.base_ref || github.ref_name }}"
+              fi
+              echo "branch_name=$BRANCH" >> "$GITHUB_OUTPUT"
+
+              # Severity prefix for stable/* branches (production-relevant failures)
+              if [[ "$BRANCH" == stable/* ]]; then
+                echo "severity_prefix=:rotating_light: *STABLE BRANCH FAILURE* :rotating_light:" >> "$GITHUB_OUTPUT"
+              else
+                echo "severity_prefix=" >> "$GITHUB_OUTPUT"
+              fi
+
+              # Mention suffix — omit entirely if slack_mention_people is empty
+              MENTION="${{ inputs.slack_mention_people }}"
+              if [[ -n "$MENTION" ]]; then
+                echo "mention_suffix= (cc $MENTION)" >> "$GITHUB_OUTPUT"
+              else
+                echo "mention_suffix=" >> "$GITHUB_OUTPUT"
+              fi
+
         - name: Import Secrets
           id: secrets
           if: ${{ steps.silence-check.outcome != 'success' }} # in case of success it means that a silence issue exists
@@ -97,13 +131,13 @@ runs:
                     "channel" : "${{ inputs.slack_channel_id }}",
                     "unfurl_links": false,
                     "unfurl_media": false,
-                    "text": "${{ github.event.repository.name }} (${{ github.server_url }}/${{ github.repository }}) scheduled workflow: ${{ github.workflow }} failed! Please check: ${{ env.WORKFLOW_URL }} (cc ${{ inputs.slack_mention_people }})",
+                    "text": "${{ steps.context.outputs.severity_prefix != '' && format('{0} ', steps.context.outputs.severity_prefix) || '' }}${{ github.event.repository.name }} workflow: ${{ github.workflow }} failed on ${{ steps.context.outputs.branch_name }}! Please check: ${{ env.WORKFLOW_URL }}${{ steps.context.outputs.mention_suffix }}",
                     "blocks": [
                       {
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":automation-platform-failure: :mechanic: <${{ github.server_url }}/${{ github.repository }}|[${{ github.event.repository.name }}]> scheduled workflow: ${{ github.workflow }} failed! \n :link: Please check: ${{ env.WORKFLOW_URL }} \n (cc ${{ inputs.slack_mention_people }})"
+                          "text": "${{ steps.context.outputs.severity_prefix != '' && format('{0}\n', steps.context.outputs.severity_prefix) || '' }}:automation-platform-failure: :mechanic: <${{ github.server_url }}/${{ github.repository }}|[${{ github.event.repository.name }}]> workflow: ${{ github.workflow }} failed!\n:seedling: Branch: `${{ steps.context.outputs.branch_name }}`\n:link: Please check: ${{ env.WORKFLOW_URL }}${{ steps.context.outputs.mention_suffix }}"
                         }
                       }
                     ]

--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -32,8 +32,9 @@ inputs:
     branch:
         description: |
             The branch the workflow is testing. Used to add severity context to the Slack alert.
-            Defaults to auto-detection: github.base_ref for PRs (target branch), github.ref_name for push/schedule events.
-            Alerts on stable/* branches include a prominent severity marker.
+            Defaults to auto-detection: `github.base_ref` for PRs (target branch),
+            `github.ref_name` for push/schedule events.
+            Alerts on `stable/*` branches include a prominent severity marker.
         required: false
         default: ''
 
@@ -83,28 +84,58 @@ runs:
           id: context
           if: ${{ steps.silence-check.outcome != 'success' }} # in case of success it means that a silence issue exists
           shell: bash
+          env:
+              BRANCH_INPUT: ${{ inputs.branch }}
+              DEFAULT_BRANCH: ${{ github.base_ref || github.ref_name }}
+              MENTION: ${{ inputs.slack_mention_people }}
+              REPO_NAME: ${{ github.event.repository.name }}
+              REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+              WORKFLOW_NAME: ${{ github.workflow }}
+              WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           run: |
+              set -euo pipefail
+
               # Resolve branch: explicit input > PR base ref (target branch) > current ref
-              BRANCH="${{ inputs.branch }}"
+              BRANCH="$BRANCH_INPUT"
               if [[ -z "$BRANCH" ]]; then
-                BRANCH="${{ github.base_ref || github.ref_name }}"
+                BRANCH="$DEFAULT_BRANCH"
               fi
-              echo "branch_name=$BRANCH" >> "$GITHUB_OUTPUT"
 
               # Severity prefix for stable/* branches (production-relevant failures)
               if [[ "$BRANCH" == stable/* ]]; then
-                echo "severity_prefix=:rotating_light: *STABLE BRANCH FAILURE* :rotating_light:" >> "$GITHUB_OUTPUT"
+                SEVERITY_PREFIX=":rotating_light: *STABLE BRANCH FAILURE* :rotating_light:"
               else
-                echo "severity_prefix=" >> "$GITHUB_OUTPUT"
+                SEVERITY_PREFIX=""
               fi
 
               # Mention suffix — omit entirely if slack_mention_people is empty
-              MENTION="${{ inputs.slack_mention_people }}"
               if [[ -n "$MENTION" ]]; then
-                echo "mention_suffix= (cc $MENTION)" >> "$GITHUB_OUTPUT"
+                MENTION_SUFFIX=" (cc $MENTION)"
               else
-                echo "mention_suffix=" >> "$GITHUB_OUTPUT"
+                MENTION_SUFFIX=""
               fi
+
+              # Build the final message strings here so the payload step only has to
+              # pass them through toJSON() — no further interpolation, no injection risk.
+              if [[ -n "$SEVERITY_PREFIX" ]]; then
+                TEXT_PLAIN="$SEVERITY_PREFIX $REPO_NAME workflow: $WORKFLOW_NAME failed on $BRANCH! Please check: $WORKFLOW_URL$MENTION_SUFFIX"
+                BLOCK_PREFIX="$SEVERITY_PREFIX"$'\n'
+              else
+                TEXT_PLAIN="$REPO_NAME workflow: $WORKFLOW_NAME failed on $BRANCH! Please check: $WORKFLOW_URL$MENTION_SUFFIX"
+                BLOCK_PREFIX=""
+              fi
+              TEXT_BLOCK="${BLOCK_PREFIX}:automation-platform-failure: :mechanic: <${REPO_URL}|[${REPO_NAME}]> workflow: ${WORKFLOW_NAME} failed!"$'\n'":seedling: Branch: \`${BRANCH}\`"$'\n'":link: Please check: ${WORKFLOW_URL}${MENTION_SUFFIX}"
+
+              {
+                echo "branch_name=$BRANCH"
+                # Multiline-safe output using GitHub Actions delimiters
+                echo "text_plain<<EOF_TEXT_PLAIN"
+                printf '%s\n' "$TEXT_PLAIN"
+                echo "EOF_TEXT_PLAIN"
+                echo "text_block<<EOF_TEXT_BLOCK"
+                printf '%s\n' "$TEXT_BLOCK"
+                echo "EOF_TEXT_BLOCK"
+              } >> "$GITHUB_OUTPUT"
 
         - name: Import Secrets
           id: secrets
@@ -128,16 +159,16 @@ runs:
               token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
               payload: |
                   {
-                    "channel" : "${{ inputs.slack_channel_id }}",
+                    "channel": ${{ toJSON(inputs.slack_channel_id) }},
                     "unfurl_links": false,
                     "unfurl_media": false,
-                    "text": "${{ steps.context.outputs.severity_prefix != '' && format('{0} ', steps.context.outputs.severity_prefix) || '' }}${{ github.event.repository.name }} workflow: ${{ github.workflow }} failed on ${{ steps.context.outputs.branch_name }}! Please check: ${{ env.WORKFLOW_URL }}${{ steps.context.outputs.mention_suffix }}",
+                    "text": ${{ toJSON(steps.context.outputs.text_plain) }},
                     "blocks": [
                       {
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": "${{ steps.context.outputs.severity_prefix != '' && format('{0}\n', steps.context.outputs.severity_prefix) || '' }}:automation-platform-failure: :mechanic: <${{ github.server_url }}/${{ github.repository }}|[${{ github.event.repository.name }}]> workflow: ${{ github.workflow }} failed!\n:seedling: Branch: `${{ steps.context.outputs.branch_name }}`\n:link: Please check: ${{ env.WORKFLOW_URL }}${{ steps.context.outputs.mention_suffix }}"
+                          "text": ${{ toJSON(steps.context.outputs.text_block) }}
                         }
                       }
                     ]

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -170,12 +170,12 @@ jobs:
                   GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
               run: .github/workflows/scripts/aws_global_cleanup.sh
 
-            # This is likely to fail, therefore we ignore the error
-            # (timeout-minutes would otherwise fail the job despite `|| true`,
-            # so we also set continue-on-error to truly tolerate timeouts here)
+            # This is likely to fail, therefore we ignore the error via
+            # `continue-on-error: true` (which also covers timeout-minutes
+            # killing the step, unlike a shell-level `|| true`).
             # We're ignoring ec2-dhcp-option as they couldn't be deleted
             # cloudtrail is managed by IT and can't be deleted either
-            - name: Run Cloud Nuke
+            - name: Run Cloud Nuke (best-effort)
               timeout-minutes: 90
               continue-on-error: true
               env:
@@ -190,10 +190,10 @@ jobs:
                   --exclude-resource-type ec2-keypairs \
                   --exclude-resource-type guard-duty \
                   --exclude-resource-type s3 \
-                  --exclude-resource-type cloudtrail || true
+                  --exclude-resource-type cloudtrail
 
             # The second run should remove the remaining resources (VPCs) and fail if there's anything left
-            - name: Run Cloud Nuke
+            - name: Run Cloud Nuke (strict)
               timeout-minutes: 90
               env:
                   DISABLE_TELEMETRY: 'true'

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -171,10 +171,13 @@ jobs:
               run: .github/workflows/scripts/aws_global_cleanup.sh
 
             # This is likely to fail, therefore we ignore the error
+            # (timeout-minutes would otherwise fail the job despite `|| true`,
+            # so we also set continue-on-error to truly tolerate timeouts here)
             # We're ignoring ec2-dhcp-option as they couldn't be deleted
             # cloudtrail is managed by IT and can't be deleted either
             - name: Run Cloud Nuke
               timeout-minutes: 90
+              continue-on-error: true
               env:
                   DISABLE_TELEMETRY: 'true'
               if: ${{ env.should_run == 'true' }}


### PR DESCRIPTION
## Summary

Enhance the `report-failure-on-slack` composite action so Slack alerts carry the context needed to triage a failure without having to open the run.

### Changes

- **New optional `branch` input.** When unset, auto-detects from `github.base_ref || github.ref_name`. For PR runs this surfaces the actual target branch (e.g. `stable/8.7` instead of `schedules/8.7`); for push/schedule events the current ref is reported.
- **Branch displayed in the alert.** The Slack message now includes a `Branch: <name>` line.
- **Severity marker for `stable/*` branches.** A prominent prefix is prepended when the branch matches `stable/*`, so production-relevant failures stand out in the alert channel.
- **Drop hardcoded "scheduled" wording.** The action is now also invoked on non-scheduled runs (PR validation, manual dispatch), so the message wording was generalised.
- **Cleaner empty mention.** When `slack_mention_people` is empty, the trailing `(cc ...)` suffix is omitted entirely instead of rendering `(cc )`.

### Backwards compatibility

`branch` is optional with a sensible default — existing consumers (pinned at `@1.6.0`) continue to work unchanged. The README is regenerated by the `update-action-readmes-docker` hook.

### Refs

camunda/team-infrastructure-experience#1106

## Test plan

- [ ] CI lint passes on the action source (actionlint, yamlfmt, README docs hook)
- [ ] Manual trigger of a workflow that uses this action on a non-stable branch — verify no severity prefix, `Branch:` line present, no `(cc )` artefact
- [ ] Manual trigger on a `stable/*` branch — verify severity prefix renders
- [ ] Scheduled run — verify message still carries the expected mention (`@infraex-medic`) and the branch is detected