### PR TITLE
fix(report-failure-on-slack): always generate token, use GH_TOKEN

### DIFF
--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -43,7 +43,10 @@ runs:
     steps:
         - name: Generate token for GitHub
           id: generate-github-token
-          if: ${{ inputs.disable_silence_check == 'false' }}
+          # Always generate: the token is consumed by both the silence-check
+          # step and the analyzer trigger step, so gating it on
+          # disable_silence_check leaves the trigger step without a token
+          # when the silence check is disabled.
           uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@732a017b858dbc516d87dbe0780fafb770532ed7 # main
           with:
               github-app-id-vault-key: GITHUB_APP_ID
@@ -190,5 +193,5 @@ runs:
 
               echo "GHA Failure Log Analyzer triggered successfully"
           env:
-              GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+              GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
               WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary

The analyzer-trigger step fails with `gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.` whenever callers pass `disable_silence_check: true`. Two issues:

1. **Token never generated when silence-check is disabled.** The `Generate token for GitHub` step is gated on `disable_silence_check == 'false'`. When callers disable the silence check, the token step is skipped, but the `Trigger GHA Failure Log Analyzer` step still runs (its only gate is `silence-check.outcome != 'success'`, and a *skipped* outcome is not 'success'). Result: `gh workflow run` is invoked with an empty token.

   Fix: generate the token unconditionally — it is consumed by both the silence check and the trigger step.

2. **`GITHUB_TOKEN` env var.** When `gh` runs cross-repo (`--repo camunda/infraex-common-config`) it prefers/requires `GH_TOKEN`. Renamed the env var to match the CLI's recommendation (the error message itself says "set the GH_TOKEN environment variable").

Repro: any workflow calling this action with `disable_silence_check: true`. Examples from `camunda-deployment-references`:
- https://github.com/camunda/camunda-deployment-references/actions/runs/26217306257/job/77154219146 (PR #2400)
- https://github.com/camunda/camunda-deployment-references/actions/runs/26217643576/job/77175761875 (PR #2490)

## Test plan
- [x] Verified action.yml syntax is valid
- [ ] Once merged, bump the action ref in `camunda-deployment-references` workflows that pin to `6d3ddc1`
- [ ] Confirm the analyzer-trigger step succeeds on a workflow with `disable_silence_check: true`