### PR TITLE
fix(audit): allowlist Vigie StackSet and IAM role in eu-central-1

### DIFF
--- a/.github/config/permanent_resources_allowlist.yml
+++ b/.github/config/permanent_resources_allowlist.yml
@@ -25,6 +25,7 @@ aws:
         # IAM roles
         iam_role:
             - AWSServiceRole*
+            - VigieAccessRole
         # VPCs
         vpc:
             - infraex-permanent-vpc
@@ -46,6 +47,7 @@ aws:
         cloudformation-stack:
             - StackSet-expel-*
             - StackSet-Wiz-*
+            - StackSet-VigieAccessRole-*
 
     eu-west-1:
         # GuardDuty


### PR DESCRIPTION
## Summary

The weekly [Permanent Resources Audit](https://github.com/camunda/infraex-common-config/actions/runs/26374400417) flagged a non-allowlisted resource in `eu-central-1`:

```
[cloudformation-stack] StackSet-VigieAccessRole-72df1a66-fd9c-4b84-8e35-a16a8f56efc2 (eu-central-1)
```

Vigie is security tooling — same class as the already-allowlisted Expel and Wiz StackSets. The StackSet provisions an IAM role named `VigieAccessRole`, which is also a permanent expected resource.

## Changes

Under `aws.eu-central-1` in `.github/config/permanent_resources_allowlist.yml`:

- `cloudformation-stack`: add `StackSet-VigieAccessRole-*` (wildcard mirrors the `StackSet-expel-*` / `StackSet-Wiz-*` convention and survives StackSet re-creation, which rotates the UUID suffix).
- `iam_role`: add `VigieAccessRole` (exact name — the role itself has no UUID suffix).

## Test plan

- [ ] Wait for the next scheduled "Weekly Audit of Permanent Resources" run (or trigger it manually) and confirm the Slack message no longer lists the Vigie resources.