### PR TITLE
fix(audit): allowlist MAP auto-tagging backfill StackSet and lambda in eu-central-1

### DIFF
--- a/.github/config/permanent_resources_allowlist.yml
+++ b/.github/config/permanent_resources_allowlist.yml
@@ -19,6 +19,8 @@ aws:
         # Lambda functions
         lambda:
             - medicAbsenceFormToJsonData
+            # MAP auto-tagging backfill - managed by infra IT sec (deployed via StackSet)
+            - StackSet-map-autotag-backfill-*
         # CloudWatch Log Groups
         cloudwatch-loggroup:
             - /aws/lambda/medicAbsenceFormToJsonData
@@ -48,6 +50,8 @@ aws:
             - StackSet-expel-*
             - StackSet-Wiz-*
             - StackSet-VigieAccessRole-*
+            # MAP auto-tagging backfill - managed by infra IT sec
+            - StackSet-map-autotag-backfill-*
 
     eu-west-1:
         # GuardDuty


### PR DESCRIPTION
## Summary

The weekly [Permanent Resources Audit](https://github.com/camunda/infraex-common-config/actions/workflows/permanent_resources_audit.yml) flagged non-allowlisted resources in `eu-central-1`:

```
[cloudformation-stack] StackSet-map-autotag-backfill-49a1d17a-1d75-4a70-87e2-0763480fea47 (eu-central-1)
[lambda] StackSet-map-autotag-backfill-49a-BackfillFunction-gUB1dcjznzV0 (eu-central-1)
```

These belong to the AWS MAP (Migration Acceleration Program) auto-tagging **backfill**, deployed org-wide via StackSet and **managed by the infra IT sec team**. They are expected permanent resources — same class as the already-allowlisted Expel / Wiz / Vigie StackSets.

## Changes

Under `aws.eu-central-1` in `.github/config/permanent_resources_allowlist.yml`:

- `cloudformation-stack`: add `StackSet-map-autotag-backfill-*`
- `lambda`: add `StackSet-map-autotag-backfill-*`

Wildcards mirror the existing `StackSet-expel-*` / `StackSet-Wiz-*` / `StackSet-VigieAccessRole-*` convention and survive StackSet re-creation, which rotates the generated suffixes (the StackSet instance UUID `…-49a1d17a-…` and the CloudFormation logical-id hash `…-BackfillFunction-gUB1dcjznzV0`).

## Test plan

- [x] Replayed the audit's allowlist matching logic locally against both pasted resources — both now match, and unrelated resources (e.g. `some-random-prod-lambda`) still do not.
- [x] `yamlfmt`, `trailing-whitespace` and `end-of-file-fixer` pre-commit hooks pass.
- [ ] Confirm on the next scheduled "Weekly Audit of Permanent Resources" run (or a manual `workflow_dispatch`) that the Slack message no longer lists the MAP auto-tagging resources.