### PR TITLE
feat(slack): add report-warning-on-slack composite action

### DIFF
--- a/.github/actions/report-warning-on-slack/README.md
+++ b/.github/actions/report-warning-on-slack/README.md
@@ -25,7 +25,7 @@ caller has detected findings.
 | `vault_role_id` | <p>The role ID used for authentication with Vault.</p> | `true` | `""` |
 | `vault_secret_id` | <p>The secret ID used for authentication with Vault.</p> | `true` | `""` |
 | `slack_channel_id` | <p>The Slack channel ID where the warning will be sent.</p> | `false` | `C076N4G1162` |
-| `slack_mention_people` | <p>Optional Slack handles or group mentions to cc on the warning (for example <code>@infraex-medic</code>). Left empty by default because warnings are advisory and should not page people.</p> | `false` | `""` |
+| `slack_mention_people` | <p>Optional Slack handles or group mentions to cc on the warning (for example <code>@infraex-medic</code>). Left empty by default because warnings are advisory and should not page people. Broadcast mentions (<code>&lt;!here&gt;</code>, <code>&lt;!channel&gt;</code>, <code>&lt;!everyone&gt;</code>) are defused so a warning cannot page a whole channel; user and usergroup mentions still work.</p> | `false` | `""` |
 | `disable_silence_check` | <p>Disable the silence check. By default the warning can be muted by opening an issue in the repository with the label <code>alert-management</code> and the title <code>silence: &lt;name of your workflow&gt;</code>.</p> | `false` | `false` |
 | `branch` | <p>The branch the workflow is testing, shown for context. Defaults to auto-detection: <code>github.base_ref</code> for pull requests (the target branch), <code>github.ref_name</code> otherwise.</p> | `false` | `""` |
 | `title` | <p>Short headline shown after the WARNING marker.</p> | `false` | `Non-blocking warning` |
@@ -77,7 +77,10 @@ This action is a `composite` action.
     slack_mention_people:
     # Optional Slack handles or group mentions to cc on the warning
     # (for example `@infraex-medic`). Left empty by default because
-    # warnings are advisory and should not page people.
+    # warnings are advisory and should not page people. Broadcast
+    # mentions (`<!here>`, `<!channel>`, `<!everyone>`) are defused so a
+    # warning cannot page a whole channel; user and usergroup mentions
+    # still work.
     #
     # Required: false
     # Default: ""

--- a/.github/actions/report-warning-on-slack/README.md
+++ b/.github/actions/report-warning-on-slack/README.md
@@ -1,0 +1,120 @@
+# Report Warning and Notify Slack
+
+## Description
+
+Companion to report-failure-on-slack for NON-blocking findings.
+
+Imports the Slack bot token from HashiCorp Vault and posts a clearly
+warning-styled Slack notification. Unlike report-failure-on-slack, it does
+not frame the message as a failure: there is no :rotating_light: severity
+frame, no "failed!" wording, no STABLE BRANCH FAILURE / REPEATED FAILURE
+escalation, no consecutive-failure tracking, and it does not trigger the
+GHA Failure Log Analyzer.
+
+Use it for advisory signals (for example Helm deprecation or unknown-key
+configuration drift) that must be surfaced but must not look like a red CI
+failure. Typically called from a step guarded with `if: always()` once the
+caller has detected findings.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `vault_addr` | <p>The address of the Vault instance.</p> | `true` | `""` |
+| `vault_role_id` | <p>The role ID used for authentication with Vault.</p> | `true` | `""` |
+| `vault_secret_id` | <p>The secret ID used for authentication with Vault.</p> | `true` | `""` |
+| `slack_channel_id` | <p>The Slack channel ID where the warning will be sent.</p> | `false` | `C076N4G1162` |
+| `slack_mention_people` | <p>Optional Slack handles or group mentions to cc on the warning (for example <code>@infraex-medic</code>). Left empty by default because warnings are advisory and should not page people.</p> | `false` | `""` |
+| `disable_silence_check` | <p>Disable the silence check. By default the warning can be muted by opening an issue in the repository with the label <code>alert-management</code> and the title <code>silence: &lt;name of your workflow&gt;</code>.</p> | `false` | `false` |
+| `branch` | <p>The branch the workflow is testing, shown for context. Defaults to auto-detection: <code>github.base_ref</code> for pull requests (the target branch), <code>github.ref_name</code> otherwise.</p> | `false` | `""` |
+| `title` | <p>Short headline shown after the WARNING marker.</p> | `false` | `Non-blocking warning` |
+| `message` | <p>Optional extra context line rendered under the header (plain text; no Slack markup is injected by the caller-provided value).</p> | `false` | `""` |
+| `github_token` | <p>Token used only for the silence-issue lookup. Needs read access to issues on the current repository. Defaults to the workflow token.</p> | `false` | `${{ github.token }}` |
+
+
+## Outputs
+
+| name | description |
+| --- | --- |
+| `ts` | <p>Slack message timestamp (thread id) of the posted warning. Empty when the notification was skipped (silenced).</p> |
+| `silenced` | <p><code>true</code> when a matching silence issue suppressed the warning.</p> |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@main
+  with:
+    vault_addr:
+    # The address of the Vault instance.
+    #
+    # Required: true
+    # Default: ""
+
+    vault_role_id:
+    # The role ID used for authentication with Vault.
+    #
+    # Required: true
+    # Default: ""
+
+    vault_secret_id:
+    # The secret ID used for authentication with Vault.
+    #
+    # Required: true
+    # Default: ""
+
+    slack_channel_id:
+    # The Slack channel ID where the warning will be sent.
+    #
+    # Required: false
+    # Default: C076N4G1162
+
+    slack_mention_people:
+    # Optional Slack handles or group mentions to cc on the warning
+    # (for example `@infraex-medic`). Left empty by default because
+    # warnings are advisory and should not page people.
+    #
+    # Required: false
+    # Default: ""
+
+    disable_silence_check:
+    # Disable the silence check. By default the warning can be muted by
+    # opening an issue in the repository with the label `alert-management`
+    # and the title `silence: <name of your workflow>`.
+    #
+    # Required: false
+    # Default: false
+
+    branch:
+    # The branch the workflow is testing, shown for context.
+    # Defaults to auto-detection: `github.base_ref` for pull requests
+    # (the target branch), `github.ref_name` otherwise.
+    #
+    # Required: false
+    # Default: ""
+
+    title:
+    # Short headline shown after the WARNING marker.
+    #
+    # Required: false
+    # Default: Non-blocking warning
+
+    message:
+    # Optional extra context line rendered under the header (plain text;
+    # no Slack markup is injected by the caller-provided value).
+    #
+    # Required: false
+    # Default: ""
+
+    github_token:
+    # Token used only for the silence-issue lookup. Needs read access to
+    # issues on the current repository. Defaults to the workflow token.
+    #
+    # Required: false
+    # Default: ${{ github.token }}
+```

--- a/.github/actions/report-warning-on-slack/README.md
+++ b/.github/actions/report-warning-on-slack/README.md
@@ -29,7 +29,7 @@ caller has detected findings.
 | `disable_silence_check` | <p>Disable the silence check. By default the warning can be muted by opening an issue in the repository with the label <code>alert-management</code> and the title <code>silence: &lt;name of your workflow&gt;</code>.</p> | `false` | `false` |
 | `branch` | <p>The branch the workflow is testing, shown for context. Defaults to auto-detection: <code>github.base_ref</code> for pull requests (the target branch), <code>github.ref_name</code> otherwise.</p> | `false` | `""` |
 | `title` | <p>Short headline shown after the WARNING marker.</p> | `false` | `Non-blocking warning` |
-| `message` | <p>Optional extra context line rendered under the header (plain text; no Slack markup is injected by the caller-provided value).</p> | `false` | `""` |
+| `message` | <p>Optional extra context line rendered under the header. Slack metacharacters (<code>&amp;</code>, <code>&lt;</code>, <code>&gt;</code>) in the value are escaped, so it cannot inject links or broadcast mentions (for example <code>&lt;!here&gt;</code>).</p> | `false` | `""` |
 | `github_token` | <p>Token used only for the silence-issue lookup. Needs read access to issues on the current repository. Defaults to the workflow token.</p> | `false` | `${{ github.token }}` |
 
 
@@ -105,8 +105,9 @@ This action is a `composite` action.
     # Default: Non-blocking warning
 
     message:
-    # Optional extra context line rendered under the header (plain text;
-    # no Slack markup is injected by the caller-provided value).
+    # Optional extra context line rendered under the header. Slack
+    # metacharacters (`&`, `<`, `>`) in the value are escaped, so it
+    # cannot inject links or broadcast mentions (for example `<!here>`).
     #
     # Required: false
     # Default: ""

--- a/.github/actions/report-warning-on-slack/action.yml
+++ b/.github/actions/report-warning-on-slack/action.yml
@@ -56,8 +56,9 @@ inputs:
         default: Non-blocking warning
     message:
         description: |
-            Optional extra context line rendered under the header (plain text;
-            no Slack markup is injected by the caller-provided value).
+            Optional extra context line rendered under the header. Slack
+            metacharacters (`&`, `<`, `>`) in the value are escaped, so it
+            cannot inject links or broadcast mentions (for example `<!here>`).
         required: false
         default: ''
     github_token:
@@ -75,7 +76,7 @@ outputs:
         value: ${{ steps.slack-notification.outputs.ts }}
     silenced:
         description: '`true` when a matching silence issue suppressed the warning.'
-        value: ${{ steps.silence-check.outputs.silenced }}
+        value: ${{ steps.silence-check.outputs.silenced || 'false' }}
 
 runs:
     using: composite
@@ -83,6 +84,10 @@ runs:
         - name: Check for silence issue
           id: silence-check
           if: ${{ inputs.disable_silence_check == 'false' }}
+          # Fail-open: a gh/jq/API hiccup must never turn an otherwise-green
+          # workflow red, since this action only emits advisory warnings. On
+          # error the step is non-fatal and the warning is sent anyway.
+          continue-on-error: true
           shell: bash
           env:
               GH_TOKEN: ${{ inputs.github_token }}
@@ -119,6 +124,12 @@ runs:
               WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           run: |
               set -euo pipefail
+
+              # Escape Slack mrkdwn metacharacters in caller-provided strings so a
+              # title/message cannot inject links or broadcast mentions such as
+              # <!here> / <!channel>. Ampersand must be escaped first.
+              TITLE="${TITLE//&/&amp;}"; TITLE="${TITLE//</&lt;}"; TITLE="${TITLE//>/&gt;}"
+              MESSAGE="${MESSAGE//&/&amp;}"; MESSAGE="${MESSAGE//</&lt;}"; MESSAGE="${MESSAGE//>/&gt;}"
 
               # Resolve branch: explicit input > PR base ref (target branch) > current ref
               BRANCH="${BRANCH_INPUT}"

--- a/.github/actions/report-warning-on-slack/action.yml
+++ b/.github/actions/report-warning-on-slack/action.yml
@@ -33,7 +33,10 @@ inputs:
         description: |
             Optional Slack handles or group mentions to cc on the warning
             (for example `@infraex-medic`). Left empty by default because
-            warnings are advisory and should not page people.
+            warnings are advisory and should not page people. Broadcast
+            mentions (`<!here>`, `<!channel>`, `<!everyone>`) are defused so a
+            warning cannot page a whole channel; user and usergroup mentions
+            still work.
         required: false
         default: ''
     disable_silence_check:
@@ -130,6 +133,10 @@ runs:
               # <!here> / <!channel>. Ampersand must be escaped first.
               TITLE="${TITLE//&/&amp;}"; TITLE="${TITLE//</&lt;}"; TITLE="${TITLE//>/&gt;}"
               MESSAGE="${MESSAGE//&/&amp;}"; MESSAGE="${MESSAGE//</&lt;}"; MESSAGE="${MESSAGE//>/&gt;}"
+
+              # Defuse Slack broadcast mentions in the caller-provided cc list while
+              # still allowing user (<@U...>) and usergroup (<!subteam^...>) mentions.
+              MENTION=$(printf '%s' "${MENTION}" | sed -E 's/<!(here|channel|everyone)(\|[^>]*)?>/\1/g')
 
               # Resolve branch: explicit input > PR base ref (target branch) > current ref
               BRANCH="${BRANCH_INPUT}"

--- a/.github/actions/report-warning-on-slack/action.yml
+++ b/.github/actions/report-warning-on-slack/action.yml
@@ -1,0 +1,192 @@
+---
+name: Report Warning and Notify Slack
+description: |
+    Companion to report-failure-on-slack for NON-blocking findings.
+
+    Imports the Slack bot token from HashiCorp Vault and posts a clearly
+    warning-styled Slack notification. Unlike report-failure-on-slack, it does
+    not frame the message as a failure: there is no :rotating_light: severity
+    frame, no "failed!" wording, no STABLE BRANCH FAILURE / REPEATED FAILURE
+    escalation, no consecutive-failure tracking, and it does not trigger the
+    GHA Failure Log Analyzer.
+
+    Use it for advisory signals (for example Helm deprecation or unknown-key
+    configuration drift) that must be surfaced but must not look like a red CI
+    failure. Typically called from a step guarded with `if: always()` once the
+    caller has detected findings.
+
+inputs:
+    vault_addr:
+        description: The address of the Vault instance.
+        required: true
+    vault_role_id:
+        description: The role ID used for authentication with Vault.
+        required: true
+    vault_secret_id:
+        description: The secret ID used for authentication with Vault.
+        required: true
+    slack_channel_id:
+        description: The Slack channel ID where the warning will be sent.
+        required: false
+        default: C076N4G1162 # infraex-alerts
+    slack_mention_people:
+        description: |
+            Optional Slack handles or group mentions to cc on the warning
+            (for example `@infraex-medic`). Left empty by default because
+            warnings are advisory and should not page people.
+        required: false
+        default: ''
+    disable_silence_check:
+        description: |
+            Disable the silence check. By default the warning can be muted by
+            opening an issue in the repository with the label `alert-management`
+            and the title `silence: <name of your workflow>`.
+        required: false
+        default: 'false'
+    branch:
+        description: |
+            The branch the workflow is testing, shown for context.
+            Defaults to auto-detection: `github.base_ref` for pull requests
+            (the target branch), `github.ref_name` otherwise.
+        required: false
+        default: ''
+    title:
+        description: Short headline shown after the WARNING marker.
+        required: false
+        default: Non-blocking warning
+    message:
+        description: |
+            Optional extra context line rendered under the header (plain text;
+            no Slack markup is injected by the caller-provided value).
+        required: false
+        default: ''
+    github_token:
+        description: |
+            Token used only for the silence-issue lookup. Needs read access to
+            issues on the current repository. Defaults to the workflow token.
+        required: false
+        default: ${{ github.token }}
+
+outputs:
+    ts:
+        description: |
+            Slack message timestamp (thread id) of the posted warning. Empty
+            when the notification was skipped (silenced).
+        value: ${{ steps.slack-notification.outputs.ts }}
+    silenced:
+        description: '`true` when a matching silence issue suppressed the warning.'
+        value: ${{ steps.silence-check.outputs.silenced }}
+
+runs:
+    using: composite
+    steps:
+        - name: Check for silence issue
+          id: silence-check
+          if: ${{ inputs.disable_silence_check == 'false' }}
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github_token }}
+              WORKFLOW: ${{ github.workflow }}
+              REPO: ${{ github.repository }}
+          run: |
+              set -euo pipefail
+              ISSUE_TITLE="silence: ${WORKFLOW}"
+              MATCHES=$(gh issue list --repo "${REPO}" --state open \
+                --search "${ISSUE_TITLE} in:title" --label alert-management \
+                --json number,title,url)
+              if [[ "$(echo "${MATCHES}" | jq 'length')" -gt 0 ]]; then
+                URL=$(echo "${MATCHES}" | jq -r '.[0].url')
+                echo "Silence issue active (${URL}); skipping Slack warning."
+                echo "silenced=true" >> "${GITHUB_OUTPUT}"
+              else
+                echo "No silence issue found; the warning will be sent."
+                echo "silenced=false" >> "${GITHUB_OUTPUT}"
+              fi
+
+        - name: Prepare notification context
+          id: context
+          if: ${{ steps.silence-check.outputs.silenced != 'true' }}
+          shell: bash
+          env:
+              BRANCH_INPUT: ${{ inputs.branch }}
+              DEFAULT_BRANCH: ${{ github.base_ref || github.ref_name }}
+              MENTION: ${{ inputs.slack_mention_people }}
+              MESSAGE: ${{ inputs.message }}
+              REPO_NAME: ${{ github.event.repository.name }}
+              REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+              TITLE: ${{ inputs.title }}
+              WORKFLOW_NAME: ${{ github.workflow }}
+              WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          run: |
+              set -euo pipefail
+
+              # Resolve branch: explicit input > PR base ref (target branch) > current ref
+              BRANCH="${BRANCH_INPUT}"
+              if [[ -z "${BRANCH}" ]]; then
+                BRANCH="${DEFAULT_BRANCH}"
+              fi
+
+              # Mention suffix — omitted entirely when slack_mention_people is empty
+              if [[ -n "${MENTION}" ]]; then
+                MENTION_SUFFIX=" (cc ${MENTION})"
+              else
+                MENTION_SUFFIX=""
+              fi
+
+              # Optional context line, only rendered when a message was provided
+              if [[ -n "${MESSAGE}" ]]; then
+                MESSAGE_LINE=$'\n'":information_source: ${MESSAGE}"
+              else
+                MESSAGE_LINE=""
+              fi
+
+              # Build the final strings here so the payload step only passes them
+              # through toJSON() — no further interpolation, no injection risk.
+              TEXT_PLAIN=":warning: WARNING — ${TITLE}: ${REPO_NAME} workflow ${WORKFLOW_NAME} on ${BRANCH}. ${MESSAGE} See: ${WORKFLOW_URL}${MENTION_SUFFIX}"
+              TEXT_BLOCK=":warning: *WARNING — ${TITLE}*"$'\n'":mag: <${REPO_URL}|[${REPO_NAME}]> workflow: ${WORKFLOW_NAME}"$'\n'":seedling: Branch: \`${BRANCH}\`"${MESSAGE_LINE}$'\n'":link: ${WORKFLOW_URL}${MENTION_SUFFIX}"
+
+              {
+                echo "text_plain<<EOF_TEXT_PLAIN"
+                printf '%s\n' "${TEXT_PLAIN}"
+                echo "EOF_TEXT_PLAIN"
+                echo "text_block<<EOF_TEXT_BLOCK"
+                printf '%s\n' "${TEXT_BLOCK}"
+                echo "EOF_TEXT_BLOCK"
+              } >> "${GITHUB_OUTPUT}"
+
+        - name: Import Secrets
+          id: secrets
+          if: ${{ steps.silence-check.outputs.silenced != 'true' }}
+          uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4
+          with:
+              url: ${{ inputs.vault_addr }}
+              method: approle
+              roleId: ${{ inputs.vault_role_id }}
+              secretId: ${{ inputs.vault_secret_id }}
+              exportEnv: false
+              secrets: |
+                  secret/data/products/infrastructure-experience/ci/common SLACK_BOT_TOKEN;
+
+        - name: Notify in Slack
+          id: slack-notification
+          if: ${{ steps.silence-check.outputs.silenced != 'true' }}
+          uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+          with:
+              method: chat.postMessage
+              token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+              payload: |
+                  {
+                    "channel": ${{ toJSON(inputs.slack_channel_id) }},
+                    "unfurl_links": false,
+                    "unfurl_media": false,
+                    "text": ${{ toJSON(steps.context.outputs.text_plain) }},
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ${{ toJSON(steps.context.outputs.text_block) }}
+                        }
+                      }
+                    ]
+                  }

--- a/.github/actions/report-warning-on-slack/action.yml
+++ b/.github/actions/report-warning-on-slack/action.yml
@@ -136,6 +136,8 @@ runs:
               if [[ -z "${BRANCH}" ]]; then
                 BRANCH="${DEFAULT_BRANCH}"
               fi
+              # Escape the resolved branch too: it can be caller-provided via inputs.branch.
+              BRANCH="${BRANCH//&/&amp;}"; BRANCH="${BRANCH//</&lt;}"; BRANCH="${BRANCH//>/&gt;}"
 
               # Mention suffix — omitted entirely when slack_mention_people is empty
               if [[ -n "${MENTION}" ]]; then
@@ -144,16 +146,18 @@ runs:
                 MENTION_SUFFIX=""
               fi
 
-              # Optional context line, only rendered when a message was provided
+              # Optional context fragments, only rendered when a message was provided
               if [[ -n "${MESSAGE}" ]]; then
                 MESSAGE_LINE=$'\n'":information_source: ${MESSAGE}"
+                MESSAGE_PLAIN=" ${MESSAGE}"
               else
                 MESSAGE_LINE=""
+                MESSAGE_PLAIN=""
               fi
 
               # Build the final strings here so the payload step only passes them
               # through toJSON() — no further interpolation, no injection risk.
-              TEXT_PLAIN=":warning: WARNING — ${TITLE}: ${REPO_NAME} workflow ${WORKFLOW_NAME} on ${BRANCH}. ${MESSAGE} See: ${WORKFLOW_URL}${MENTION_SUFFIX}"
+              TEXT_PLAIN=":warning: WARNING — ${TITLE}: ${REPO_NAME} workflow ${WORKFLOW_NAME} on ${BRANCH}.${MESSAGE_PLAIN} See: ${WORKFLOW_URL}${MENTION_SUFFIX}"
               TEXT_BLOCK=":warning: *WARNING — ${TITLE}*"$'\n'":mag: <${REPO_URL}|[${REPO_NAME}]> workflow: ${WORKFLOW_NAME}"$'\n'":seedling: Branch: \`${BRANCH}\`"${MESSAGE_LINE}$'\n'":link: ${WORKFLOW_URL}${MENTION_SUFFIX}"
 
               {


### PR DESCRIPTION
## What

Adds a new composite action `report-warning-on-slack`, an advisory/non-blocking counterpart to `report-failure-on-slack`.

It imports the Slack bot token from Vault and posts a **warning-styled** message:
- `:warning:` framing (no `:rotating_light:`, no `failed!` wording)
- no `STABLE BRANCH FAILURE` / `REPEATED FAILURE` escalation
- no consecutive-failure cache tracking
- does **not** trigger the GHA Failure Log Analyzer
- keeps the silence-issue mechanism (`silence: <workflow>` + `alert-management` label)
- optional `title` / `message` context lines, optional `slack_mention_people` (empty by default — warnings should not page)

## Why

Non-blocking findings (e.g. Helm deprecation / unknown configuration keys from `internal-helm-deprecation-check`) currently reuse `report-failure-on-slack`. On scheduled `stable/*` runs this produces a red `STABLE BRANCH FAILURE` alert that links to a **green** run — a false alarm. This action lets callers surface those findings as an explicit warning instead.

## Consumer

`camunda/camunda-deployment-references` `internal-helm-deprecation-check` will switch its scheduled-findings Slack step from `report-failure-on-slack` to this action (separate PRs on `main` + `stable/8.9`).

## Notes

- README is generated by the repo's `update-action-readmes-docker` hook (`action-docs`).
- `actionlint` only targets workflow files, so composite `action.yml` files are not linted by it (same as existing actions).