### PR TITLE
[READY] feat(renovate): add bitnami vendor-ee image custom datasources

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -279,8 +279,10 @@
     },
     // Bitnami Premium image tags published by camunda-deployment-references, one
     // self-contained JSON per image (format: json) whose releases carry {version,
-    // newDigest}. Tags look like '18.4.0-debian-12-r9', so consumers annotate
-    // 'versioning=docker'.
+    // newDigest}. Tags look like '18.4.0-debian-12-r9'; 'docker' versioning will
+    // NOT update across the '-rN' revision, so consumers must annotate the build
+    // with a regex versioning, e.g.:
+    //   versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
     'bitnami-postgresql-camunda': {
       'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_postgresql.json',
       'format': 'json',

--- a/default.json5
+++ b/default.json5
@@ -277,32 +277,37 @@
       'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/aurora_postgres_versions.txt',
       'format': 'plain',
     },
-    // Bitnami Premium (vendor-ee) image tags, listed from the upstream Broadcom
-    // registry and published by camunda-deployment-references. Tags look like
-    // '18.4.0-debian-12-r9', so consumers must annotate 'versioning=docker'.
+    // Bitnami Premium image tags published by camunda-deployment-references, one
+    // self-contained JSON per image (format: json) whose releases carry {version,
+    // newDigest}. Tags look like '18.4.0-debian-12-r9', so consumers annotate
+    // 'versioning=docker'.
     'bitnami-postgresql-camunda': {
-      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_postgresql_versions.txt',
-      'format': 'plain',
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_postgresql.json',
+      'format': 'json',
     },
     'bitnami-os-shell-camunda': {
-      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_os-shell_versions.txt',
-      'format': 'plain',
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_os-shell.json',
+      'format': 'json',
     },
     'bitnami-postgres-exporter-camunda': {
-      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_postgres-exporter_versions.txt',
-      'format': 'plain',
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_postgres-exporter.json',
+      'format': 'json',
     },
     'bitnami-elasticsearch-camunda': {
-      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_elasticsearch_versions.txt',
-      'format': 'plain',
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_elasticsearch.json',
+      'format': 'json',
     },
     'bitnami-elasticsearch-exporter-camunda': {
-      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_elasticsearch-exporter_versions.txt',
-      'format': 'plain',
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_elasticsearch-exporter.json',
+      'format': 'json',
     },
     'bitnami-keycloak-config-cli-camunda': {
-      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_keycloak-config-cli_versions.txt',
-      'format': 'plain',
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_keycloak-config-cli.json',
+      'format': 'json',
+    },
+    'bitnami-keycloak-camunda': {
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_keycloak.json',
+      'format': 'json',
     },
     'helm-camunda': {
       'defaultRegistryUrlTemplate': 'https://raw.githubusercontent.com/camunda/camunda-platform-helm/refs/heads/main/.tool-versions',

--- a/default.json5
+++ b/default.json5
@@ -277,6 +277,33 @@
       'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/aurora_postgres_versions.txt',
       'format': 'plain',
     },
+    // Bitnami Premium (vendor-ee) image tags, listed from the upstream Broadcom
+    // registry and published by camunda-deployment-references. Tags look like
+    // '18.4.0-debian-12-r9', so consumers must annotate 'versioning=docker'.
+    'bitnami-postgresql-camunda': {
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_postgresql_versions.txt',
+      'format': 'plain',
+    },
+    'bitnami-os-shell-camunda': {
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_os-shell_versions.txt',
+      'format': 'plain',
+    },
+    'bitnami-postgres-exporter-camunda': {
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_postgres-exporter_versions.txt',
+      'format': 'plain',
+    },
+    'bitnami-elasticsearch-camunda': {
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_elasticsearch_versions.txt',
+      'format': 'plain',
+    },
+    'bitnami-elasticsearch-exporter-camunda': {
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_elasticsearch-exporter_versions.txt',
+      'format': 'plain',
+    },
+    'bitnami-keycloak-config-cli-camunda': {
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/bitnami_keycloak-config-cli_versions.txt',
+      'format': 'plain',
+    },
     'helm-camunda': {
       'defaultRegistryUrlTemplate': 'https://raw.githubusercontent.com/camunda/camunda-platform-helm/refs/heads/main/.tool-versions',
       'format': 'plain',


### PR DESCRIPTION
## What

Adds seven renovate `customDatasources` for the Bitnami Premium images, pointing at the per-image JSON files published on gh-pages by `camunda-deployment-references`:

- `bitnami-postgresql-camunda`
- `bitnami-os-shell-camunda`
- `bitnami-postgres-exporter-camunda`
- `bitnami-elasticsearch-camunda`
- `bitnami-elasticsearch-exporter-camunda`
- `bitnami-keycloak-config-cli-camunda`
- `bitnami-keycloak-camunda`

Each is `format: json` and points at `https://camunda.github.io/camunda-deployment-references/bitnami_<image>.json`, whose `releases` carry `{version, newDigest}` (so Renovate can optionally pin the digest).

## Why

Lets renovate (ours and customers') track upstream Bitnami image tags from a creds-free public source, instead of authenticating to `registry.camunda.cloud` (whose proxy is incomplete for pre-Nov-2025 tags).

Depends on camunda/camunda-deployment-references#2765 (the workflow that generates the per-image JSON artifacts). Refs camunda/team-infrastructure-experience#1038.

## Consumer usage

Tags look like `18.4.0-debian-12-r9`. **`versioning=docker` does NOT update across the `-debian-12-rN` revision** — a renovate dry-run against the live feed confirmed it yields no updates. Use a regex versioning that captures the `-rN` build instead:

```
# renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
```

With that versioning, a dry-run correctly proposed `18.4.0-debian-12-r0` → `18.4.0-debian-12-r9`.

## Validation

- `renovate-config-validator` produces the **same** (pre-existing, version-skew) diagnostics with and without this change — no new errors introduced.
- A local `renovate --platform=local --dry-run` against the live `bitnami_postgresql.json` confirms the datasource resolves (`getReleases` OK) and, with the regex versioning above, computes the expected update.
