### PR TITLE
[READY] fix(renovate): treat aurora-postgresql major bumps as breaking

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -155,6 +155,7 @@
       matchPackageNames: [
         'amazon-eks',
         'amazon-rds-postgresql',
+        'aurora-postgresql',
         'opensearch',
         'red-hat-openshift',
       ],

--- a/default.json5
+++ b/default.json5
@@ -165,7 +165,7 @@
       draftPR: true,
       prBodyNotes: [
         '⚠️ **Breaking Changes Possible** ⚠️',
-        'This update includes a new version of a core infrastructure component (`amazon-eks`, `opensearch`, `postgresql`, or `openshift`).',
+        'This update includes a new version of a core infrastructure component (`amazon-eks`, `amazon-rds-postgresql`, `aurora-postgresql`, `opensearch`, or `red-hat-openshift`).',
         'Such updates typically introduce breaking changes and are only applied **at the beginning of a Camunda 8 release cycle**.',
         'This update **should not** be merged mid-cycle unless explicitly approved by yourself.',
       ],


### PR DESCRIPTION
## What

Add `aurora-postgresql` to the major-update guard in `default.json5` so major Amazon Aurora PostgreSQL bumps open as **draft** PRs with the "Breaking Changes Possible" note, like the other core infrastructure components (`amazon-eks`, `opensearch`, `red-hat-openshift`).

## Why

The guard rule matched `depName=amazon-rds-postgresql`, but the Aurora datasource (`custom.aurora-pg-camunda`) used across the reference architectures declares `depName=aurora-postgresql`. As a result, **major** Aurora PostgreSQL updates slipped through as normal, non-draft PRs **without** the breaking-change warning.

Surfaced by camunda/camunda-deployment-references#2663 (Aurora PostgreSQL `17 -> 18` major bump that opened as a regular PR). Aurora major upgrades are not in-place and Camunda only supports specific Aurora majors, so these must be reviewed carefully.

## Notes

- `amazon-rds-postgresql` is kept (valid `endoflife-date` product, may be consumed by sibling repos).
- `renovate-config-validator --strict` passes (validated against the pinned renovate `43.227.0`).