### PR TITLE
[READY] fix(renovate): flag all postgresql major bumps as breaking

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -158,7 +158,6 @@
         'aurora-postgresql',
         'ghcr.io/cloudnative-pg/postgresql',
         'opensearch',
-        'postgresql',
         'red-hat-openshift',
         'registry.camunda.cloud/vendor-ee/postgresql',
       ],
@@ -168,9 +167,29 @@
       draftPR: true,
       prBodyNotes: [
         '⚠️ **Breaking Changes Possible** ⚠️',
-        'This update includes a new version of a core infrastructure component (`amazon-eks`, `opensearch`, `red-hat-openshift`, or a PostgreSQL engine/image: `amazon-rds-postgresql`, `aurora-postgresql`, `ghcr.io/cloudnative-pg/postgresql`, `registry.camunda.cloud/vendor-ee/postgresql`, `postgresql`).',
+        "This update includes a new major version of a core infrastructure component (Amazon EKS, OpenSearch, OpenShift, or a PostgreSQL engine/image). See this rule's `matchPackageNames` for the exact set.",
         'Such updates typically introduce breaking changes and are only applied **at the beginning of a Camunda 8 release cycle**.',
         'This update **should not** be merged mid-cycle unless explicitly approved by yourself.',
+      ],
+    },
+    {
+      // Azure Database for PostgreSQL Flexible Server pins its major via the
+      // endoflife-date PostgreSQL product (depName `postgresql`). Scope the match
+      // to that datasource so it cannot also match an unrelated package literally
+      // named `postgresql` (e.g. a Bitnami Helm chart) in a consuming repo.
+      matchDatasources: [
+        'endoflife-date',
+      ],
+      matchPackageNames: [
+        'postgresql',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      draftPR: true,
+      prBodyNotes: [
+        '⚠️ **Breaking Changes Possible** ⚠️',
+        'This is a major PostgreSQL upgrade. PostgreSQL major upgrades are not in-place and must be reviewed; apply only at the beginning of a Camunda 8 release cycle unless explicitly approved.',
       ],
     },
     {

--- a/default.json5
+++ b/default.json5
@@ -156,8 +156,11 @@
         'amazon-eks',
         'amazon-rds-postgresql',
         'aurora-postgresql',
+        'ghcr.io/cloudnative-pg/postgresql',
         'opensearch',
+        'postgresql',
         'red-hat-openshift',
+        'registry.camunda.cloud/vendor-ee/postgresql',
       ],
       matchUpdateTypes: [
         'major',
@@ -165,7 +168,7 @@
       draftPR: true,
       prBodyNotes: [
         '⚠️ **Breaking Changes Possible** ⚠️',
-        'This update includes a new version of a core infrastructure component (`amazon-eks`, `amazon-rds-postgresql`, `aurora-postgresql`, `opensearch`, or `red-hat-openshift`).',
+        'This update includes a new version of a core infrastructure component (`amazon-eks`, `opensearch`, `red-hat-openshift`, or a PostgreSQL engine/image: `amazon-rds-postgresql`, `aurora-postgresql`, `ghcr.io/cloudnative-pg/postgresql`, `registry.camunda.cloud/vendor-ee/postgresql`, `postgresql`).',
         'Such updates typically introduce breaking changes and are only applied **at the beginning of a Camunda 8 release cycle**.',
         'This update **should not** be merged mid-cycle unless explicitly approved by yourself.',
       ],


### PR DESCRIPTION
## What

Extend the major-update guard in `default.json5` (the rule that sets `draftPR: true` + the "Breaking Changes Possible" note) to cover **all** PostgreSQL packages used across the reference architectures, not just `aurora-postgresql`:

- `ghcr.io/cloudnative-pg/postgresql` — operator-based (CloudNativePG) clusters
- `registry.camunda.cloud/vendor-ee/postgresql` — Camunda vendor PostgreSQL image
- `postgresql` — Azure Database for PostgreSQL Flexible Server (`endoflife-date` datasource), via a **dedicated rule scoped to `matchDatasources: ['endoflife-date']`**

## Why

Follow-up to #512, which added `aurora-postgresql`. The other PostgreSQL packages were still escaping the guard, so their **major** bumps opened as normal, non-draft PRs without the breaking-change warning — e.g. camunda/camunda-deployment-references#2209 (`cloudnative-pg/postgresql` `17 -> 18`).

PostgreSQL major upgrades are not in-place (they require `pg_upgrade` / dump-restore / logical replication) and must be reviewed carefully, so they should be drafted like the other core infrastructure components.

## Notes

- The Azure `postgresql` match is scoped to the `endoflife-date` datasource in its own rule, so it targets only the Azure Flexible Server product and cannot match an unrelated package literally named `postgresql` (e.g. a Bitnami Helm chart) in a consuming repo.
- The breaking-change note is generic; the package list lives only in `matchPackageNames` (single source of truth, no prose duplication / drift).
- `renovate-config-validator --strict` passes (validated against the pinned renovate `43.227.0`).