### PR TITLE
feat(aws): clean up and audit orphaned ELBv2 target groups [ready]

### DIFF
--- a/.github/workflows/permanent_resources_audit.yml
+++ b/.github/workflows/permanent_resources_audit.yml
@@ -38,6 +38,15 @@ env:
     AWS_EXCLUDED_REGIONS: '["eu-west-2", "eu-west-3", "eu-north-1", "us-east-1", "us-east-2"]'
     AZURE_EXCLUDED_REGIONS: '["swedencentral", "spaincentral"]'
 
+    # ELBv2 target group quota headroom audit thresholds. cloud-nuke does not
+    # report target groups, so orphaned ones accumulate silently until they hit
+    # the regional "Target Groups per Region" quota (default 3000) and break new
+    # ingress load balancer creation with TooManyTargetGroups. Alert to Slack when
+    # utilization reaches this percentage of the quota, or when the number of
+    # orphaned (unattached) target groups reaches this count.
+    ELBV2_TG_USAGE_WARN_PERCENT: 80
+    ELBV2_TG_ORPHAN_WARN: 50
+
 # Limit workflow to a single execution per ref
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -322,6 +331,83 @@ jobs:
                   echo "UNALLOWLISTED_COUNT=$UNALLOWLISTED_COUNT" >> "$GITHUB_OUTPUT"
                   echo "TOTAL_RESOURCES=$((ALLOWLISTED_COUNT + UNALLOWLISTED_COUNT))" >> "$GITHUB_OUTPUT"
 
+            - name: Audit ELBv2 target group quota headroom
+              if: steps.region-check.outputs.region_disabled != 'true'
+              id: tg-audit
+              env:
+                  REGION: ${{ matrix.region }}
+                  USAGE_WARN_PERCENT: ${{ env.ELBV2_TG_USAGE_WARN_PERCENT }}
+                  ORPHAN_WARN: ${{ env.ELBV2_TG_ORPHAN_WARN }}
+              run: |
+                  # cloud-nuke does not list ELBv2 target groups, so orphaned target
+                  # groups (created by Kubernetes Service type=LoadBalancer controllers
+                  # and left behind when their load balancer/cluster is deleted) pile up
+                  # unnoticed until they exhaust the regional "Target Groups per Region"
+                  # quota (default 3000) and break new ingress load balancer creation
+                  # with TooManyTargetGroups. Surface the utilization so it is never a
+                  # surprise in a permanent region.
+
+                  # Count all target groups and the orphaned (unattached) subset.
+                  # NOTE: do not use length() inside --query here. With server-side
+                  # pagination the AWS CLI evaluates the function once per page and
+                  # prints one count per page; project the ARNs (which the CLI
+                  # aggregates across pages) and count them client-side instead.
+                  tg_total=$(aws elbv2 describe-target-groups --region "$REGION" \
+                      --query 'TargetGroups[].TargetGroupArn' --output text 2>/dev/null \
+                      | tr '\t' '\n' | grep -c . || true)
+                  # The `0` backticks below are a JMESPath number literal, not a
+                  # shell command substitution: keep them single-quoted and literal.
+                  # shellcheck disable=SC2016
+                  tg_orphaned=$(aws elbv2 describe-target-groups --region "$REGION" \
+                      --query 'TargetGroups[?length(LoadBalancerArns)==`0`].TargetGroupArn' --output text 2>/dev/null \
+                      | tr '\t' '\n' | grep -c . || true)
+
+                  # Resolve the regional quota: the applied (possibly adjusted) value,
+                  # falling back to the AWS default, then to the documented default.
+                  tg_quota=$(aws service-quotas get-service-quota \
+                      --service-code elasticloadbalancing --quota-code L-B22855CB \
+                      --region "$REGION" --query 'Quota.Value' --output text 2>/dev/null || true)
+                  if [[ -z "$tg_quota" || "$tg_quota" == "None" ]]; then
+                      tg_quota=$(aws service-quotas get-aws-default-service-quota \
+                          --service-code elasticloadbalancing --quota-code L-B22855CB \
+                          --region "$REGION" --query 'Quota.Value' --output text 2>/dev/null || true)
+                  fi
+                  if [[ -z "$tg_quota" || "$tg_quota" == "None" ]]; then
+                      tg_quota=3000
+                  fi
+                  tg_quota=${tg_quota%.*} # the API returns e.g. "3000.0"
+
+                  # Integer utilization percentage, guarding against a zero quota.
+                  if [[ "$tg_quota" -gt 0 ]]; then
+                      tg_usage_percent=$(( tg_total * 100 / tg_quota ))
+                  else
+                      tg_usage_percent=0
+                  fi
+
+                  tg_alert=false
+                  if [[ "$tg_usage_percent" -ge "$USAGE_WARN_PERCENT" || "$tg_orphaned" -ge "$ORPHAN_WARN" ]]; then
+                      tg_alert=true
+                  fi
+
+                  {
+                      echo ""
+                      echo "### ELBv2 target group quota headroom"
+                      echo "Total target groups : $tg_total"
+                      echo "Orphaned (no LB)    : $tg_orphaned"
+                      echo "Regional quota      : $tg_quota"
+                      echo "Utilization         : ${tg_usage_percent}% (alert >= ${USAGE_WARN_PERCENT}%)"
+                      echo "Orphaned threshold  : alert >= ${ORPHAN_WARN} orphaned"
+                      echo "Alert triggered     : $tg_alert"
+                  } | tee -a audit_report.txt
+
+                  {
+                      echo "TG_TOTAL=$tg_total"
+                      echo "TG_ORPHANED=$tg_orphaned"
+                      echo "TG_QUOTA=$tg_quota"
+                      echo "TG_USAGE_PERCENT=$tg_usage_percent"
+                      echo "TG_ALERT=$tg_alert"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Determine Slack channel
               if: steps.region-check.outputs.region_disabled != 'true'
               id: slack-channel
@@ -413,6 +499,73 @@ jobs:
                             "text": {
                               "type": "mrkdwn",
                               "text": "ℹ️ This is a *dry-run* audit of permanent resources. No resources were deleted.\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View full audit report>"
+                            }
+                          },
+                          {
+                            "type": "context",
+                            "elements": [
+                              {
+                                "type": "mrkdwn",
+                                "text": "Run date: ${{ steps.slack-message.outputs.run_date }}"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+
+            - name: Post ELBv2 target group audit to Slack
+              if: steps.region-check.outputs.region_disabled != 'true' && steps.tg-audit.outputs.TG_ALERT == 'true'
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+              with:
+                  method: chat.postMessage
+                  token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+                  payload: |
+                      {
+                        "channel": "${{ steps.slack-channel.outputs.channel }}",
+                        "unfurl_links": false,
+                        "unfurl_media": false,
+                        "text": "⚠️ ELBv2 target group quota headroom - ${{ matrix.region }}",
+                        "blocks": [
+                          {
+                            "type": "header",
+                            "text": {
+                              "type": "plain_text",
+                              "text": "⚠️ ELBv2 Target Group Quota Headroom",
+                              "emoji": true
+                            }
+                          },
+                          {
+                            "type": "section",
+                            "fields": [
+                              {
+                                "type": "mrkdwn",
+                                "text": "*Region:*\n${{ matrix.region }}"
+                              },
+                              {
+                                "type": "mrkdwn",
+                                "text": "*Utilization:*\n${{ steps.tg-audit.outputs.TG_USAGE_PERCENT }}% of ${{ steps.tg-audit.outputs.TG_QUOTA }}"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": "*Target groups:* ${{ steps.tg-audit.outputs.TG_TOTAL }} total, *${{ steps.tg-audit.outputs.TG_ORPHANED }} orphaned* (not attached to any load balancer)."
+                            }
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": "${{ env.SLACK_MENTION }} investigate: orphaned target groups are usually leftovers from deleted Kubernetes Services of type=LoadBalancer (OpenShift router, ingress-nginx, Contour, Submariner). cloud-nuke does not remove them, so they keep accumulating until they exhaust the regional quota and break new ingress load balancer creation with a TooManyTargetGroups error."
+                            }
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": "ℹ️ This is a *read-only* audit. No resources were deleted.\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View full audit report>"
                             }
                           },
                           {

--- a/.github/workflows/scripts/aws_regional_cleanup.sh
+++ b/.github/workflows/scripts/aws_regional_cleanup.sh
@@ -253,3 +253,28 @@ if [ -n "$log_groups" ]; then
         execute_or_simulate "aws logs delete-log-group --region $region --log-group-name \"$log_group\"" || true
     done
 fi
+
+echo "Deleting orphaned ELBv2 Target Groups"
+# ELBv2 target groups are NOT handled by cloud-nuke. Target groups created by
+# in-cluster controllers for Kubernetes Services of type=LoadBalancer (OpenShift
+# router, ingress-nginx, Contour, Submariner, ...) are left behind when their
+# load balancer or the whole cluster is destroyed. They silently pile up and
+# eventually exhaust the regional "Target Groups per Region" quota (default 3000),
+# which breaks new ingress load balancer creation with a TooManyTargetGroups error.
+#
+# Delete every target group that is no longer associated with a load balancer
+# (empty LoadBalancerArns). cloud-nuke removes the load balancers (here or on a
+# previous nightly run), so the set of orphaned target groups converges over the
+# schedule. A target group still referenced by a listener cannot be deleted and
+# is skipped (best-effort, must not abort the rest of the cleanup under set -e).
+target_group_arns=$(paginate "aws elbv2 describe-target-groups --region $region" "TargetGroups[?length(LoadBalancerArns)==\`0\`].TargetGroupArn")
+
+if [ -n "$target_group_arns" ]; then
+    read -r -a target_group_arns_array <<< "$target_group_arns"
+
+    for target_group_arn in "${target_group_arns_array[@]}"
+    do
+        echo "Deleting orphaned Target Group: $target_group_arn"
+        execute_or_simulate "aws elbv2 delete-target-group --region $region --target-group-arn $target_group_arn" || true
+    done
+fi

--- a/README.md
+++ b/README.md
@@ -95,3 +95,9 @@ This provides visibility into the permanent infrastructure without affecting any
 S3 uses a single, account-wide global namespace and every bucket is pinned to one home region. The per-region audit therefore **excludes S3** and a dedicated `aws-s3-global-audit` job lists all buckets once (`aws s3api list-buckets`) and compares them against the allowlist.
 
 This avoids a blind spot: auditing S3 per-region would silently skip any bucket whose home region is excluded from the per-region matrix (e.g. `us-east-1`, see `AWS_EXCLUDED_REGIONS`). Approved buckets are listed under `aws.global.s3` in [`.github/config/permanent_resources_allowlist.yml`](.github/config/permanent_resources_allowlist.yml), regardless of region.
+
+###### ELBv2 target groups (quota headroom)
+
+cloud-nuke does not report ELBv2 target groups. Target groups created for Kubernetes Services of type `LoadBalancer` (OpenShift router, ingress-nginx, Contour, Submariner, ...) are left behind when their load balancer or cluster is deleted, and they silently accumulate until they reach the regional **Target Groups per Region** quota (default 3000). Hitting the cap breaks new ingress load balancer creation with a `TooManyTargetGroups` error.
+
+The audit therefore counts, per permanent region, the total and orphaned (unattached) target groups and compares them against the regional quota. It posts a Slack warning when utilization reaches `ELBV2_TG_USAGE_WARN_PERCENT` (default 80%) of the quota, or when the number of orphaned target groups reaches `ELBV2_TG_ORPHAN_WARN` (default 50). In the CI regions, these orphaned target groups are deleted automatically by the [nightly cleanup](.github/workflows/aws_nightly_cleanup.yml).


### PR DESCRIPTION
## Context

A new ingress-controller load balancer creation failed in `eu-west-2` with
`TooManyTargetGroups` — the region had hit the **Target Groups per Region**
quota (3000/3000).

Investigation (AWS CLI) showed the cap was 100% leaked resources:

- **3000/3000** target groups, **0** attached to any of the 26 live load balancers.
- Owned by **1149 destroyed clusters** (no EC2 instances left), ~2.6 TG/cluster.
- Created by per-cluster controllers and never garbage-collected on teardown:
  `openshift-ingress/router-default` (1832), `submariner-operator/submariner-gateway` (702),
  `ingress-nginx/ingress-nginx-controller` (260), `projectcontour/contour-envoy` (202).

Root cause: **cloud-nuke deletes load balancers but not standalone ELBv2 target
groups**, so they accumulate until the quota is exhausted and block new ingress LBs.

## Changes

### 1. Clean up (CI regions) — `aws_regional_cleanup.sh`
Delete every target group no longer associated with a load balancer (empty
`LoadBalancerArns`). cloud-nuke removes the load balancers, so the orphan set
converges over the nightly schedule. Best-effort: a target group still referenced
by a listener cannot be deleted and is skipped. Honors `DRY_RUN`.

### 2. Audit (permanent regions) — `permanent_resources_audit.yml`
cloud-nuke never lists target groups, so the weekly audit was blind to this
growth. Add a per-region, read-only check that reports total + orphaned target
groups and quota utilization, and posts a Slack warning when:
- utilization ≥ `ELBV2_TG_USAGE_WARN_PERCENT` (default **80%**) of the regional quota, or
- orphaned target groups ≥ `ELBV2_TG_ORPHAN_WARN` (default **50**).

The quota is resolved from Service Quotas (applied → AWS default → documented 3000),
so a missing `servicequotas` permission degrades gracefully instead of failing.

## Validation
- `shellcheck` clean; `actionlint` + `yamlfmt` + whitespace/EOF pre-commit hooks pass.
- Audit logic smoke-tested against real regions:
  - `eu-west-2`: total=3000 orphaned=3000 quota=3000 usage=100% **alert=true**
  - `eu-central-1`: total=2 orphaned=2 usage=0% alert=false
  - `eu-west-1`: total=0 usage=0% alert=false
- The nightly-cleanup and audit workflows both trigger on `pull_request` for the
  changed files, so this PR exercises both paths in dry-run / read-only mode.

> Counting note: `length()` in `--query` returns a **per-page** count under
> server-side pagination, so counts are done by projecting ARNs and counting
> client-side.