### PR TITLE
feat(aws): add eu-central-2 as a daily CI region and eu-south-1 as a weekly work region [ready]

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -105,7 +105,18 @@ jobs:
                     - region: eu-west-3
                       day: All
                       cleanup_older_than: 12h
+                    # Third CI region, used by the multi-region reference
+                    # architectures that need more than two regions to keep a
+                    # Raft quorum. Opt-in region: see the accessibility guard below.
+                    - region: eu-central-2
+                      day: All
+                      cleanup_older_than: 12h
                     - region: eu-north-1
+                      day: Saturday
+                      cleanup_older_than: 0h
+                    # Fourth region available to multi-region work, kept weekly so
+                    # a topology can survive a work week. Opt-in region.
+                    - region: eu-south-1
                       day: Saturday
                       cleanup_older_than: 0h
                     - region: us-east-1
@@ -189,6 +200,27 @@ jobs:
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
                   aws-profile: ${{ env.AWS_PROFILE }}
                   aws-region: ${{ matrix.config.region }}
+
+            # Some of the regions above are AWS opt-in regions: they only answer
+            # once enabled on the account. Skip them instead of failing the whole
+            # nightly run (and paging #infraex on Slack) while enablement is
+            # pending. Mirrors the guard in permanent_resources_audit.yml.
+            - name: Check region accessibility
+              if: ${{ env.should_run == 'true' }}
+              run: |
+                  REGION="${{ env.AWS_REGION }}"
+                  if OUTPUT=$(aws ec2 describe-availability-zones --region "$REGION" 2>&1); then
+                      echo "✅ Region $REGION is accessible"
+                      exit 0
+                  fi
+                  if echo "$OUTPUT" | grep -qiE 'UnauthorizedOperation|AuthFailure|OptInRequired|InvalidClientTokenId|AccessDenied|not enabled|not subscribed'; then
+                      echo "⏭️ Region $REGION is not enabled on this account (opt-in required). Skipping its cleanup."
+                      echo "should_run=false" | tee -a "$GITHUB_ENV"
+                      exit 0
+                  fi
+                  echo "❌ Unexpected error checking region $REGION:"
+                  echo "$OUTPUT"
+                  exit 1
 
             - name: Install Cloud Nuke
               if: ${{ env.should_run == 'true' }}

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -107,7 +107,7 @@ jobs:
                       cleanup_older_than: 12h
                     # Third CI region, used by the multi-region reference
                     # architectures that need more than two regions to keep a
-                    # Raft quorum. Opt-in region: see the opt-in status guard below.
+                    # Raft quorum.
                     - region: eu-central-2
                       day: All
                       cleanup_older_than: 12h
@@ -115,8 +115,7 @@ jobs:
                       day: Saturday
                       cleanup_older_than: 0h
                     # Fourth region available to multi-region work, kept weekly so
-                    # a topology can survive a work week. Opt-in region: see the opt-in
-                    # status guard below.
+                    # a topology can survive a work week.
                     - region: eu-south-1
                       day: Saturday
                       cleanup_older_than: 0h
@@ -201,65 +200,6 @@ jobs:
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
                   aws-profile: ${{ env.AWS_PROFILE }}
                   aws-region: ${{ matrix.config.region }}
-
-            # Some of the regions above are AWS opt-in regions: they cannot be
-            # used until the account opts in. Skip those instead of failing the
-            # whole nightly run (and paging #infraex on Slack) while enablement
-            # is pending.
-            #
-            # The opt-in status is read authoritatively from DescribeRegions
-            # rather than inferred from the error text of a call to the region
-            # itself. Matching error strings would also swallow generic
-            # credential and permission failures (AuthFailure, AccessDenied,
-            # InvalidClientTokenId), silently skipping the cleanup and leaking
-            # resources behind a green run.
-            #
-            # The query is issued against a region that is enabled by default,
-            # so a broken credential fails the call — and therefore the step —
-            # instead of being misread as "region disabled".
-            - name: Check region opt-in status
-              if: ${{ env.should_run == 'true' }}
-              env:
-                  # Enabled by default (launched before March 2019), so it always
-                  # answers as long as the credentials are valid.
-                  QUERY_REGION: eu-west-2
-              run: |
-                  REGION="${{ env.AWS_REGION }}"
-
-                  # Fails the step on a credential or permission error, which is
-                  # the behaviour we want: a cleanup that cannot run must be
-                  # loud, not silently skipped.
-                  OPT_STATUS=$(aws ec2 describe-regions \
-                      --region "$QUERY_REGION" \
-                      --all-regions \
-                      --region-names "$REGION" \
-                      --query 'Regions[0].OptInStatus' \
-                      --output text)
-
-                  case "$OPT_STATUS" in
-                      opted-in|opt-in-not-required)
-                          echo "✅ Region $REGION is enabled ($OPT_STATUS)"
-                          ;;
-                      not-opted-in)
-                          # Skipping rather than failing keeps a newly added
-                          # opt-in region from breaking the nightly run before
-                          # it is enabled.
-                          #
-                          # It is still surfaced as a warning, because the other
-                          # way to reach this state is a region that WAS enabled
-                          # being disabled again — and a disabled region keeps
-                          # billing for resources that are now unreachable and
-                          # no longer swept. That must not hide behind a green
-                          # run.
-                          echo "::warning title=Region $REGION not enabled::Skipping cleanup for $REGION ($OPT_STATUS). If this region is expected to be enabled, resources in it are no longer being swept and keep incurring charges."
-                          echo "⏭️ Region $REGION is not enabled on this account ($OPT_STATUS). Skipping its cleanup."
-                          echo "should_run=false" | tee -a "$GITHUB_ENV"
-                          ;;
-                      *)
-                          echo "❌ Unexpected opt-in status for $REGION: '$OPT_STATUS'" >&2
-                          exit 1
-                          ;;
-                  esac
 
             - name: Install Cloud Nuke
               if: ${{ env.should_run == 'true' }}

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -201,26 +201,53 @@ jobs:
                   aws-profile: ${{ env.AWS_PROFILE }}
                   aws-region: ${{ matrix.config.region }}
 
-            # Some of the regions above are AWS opt-in regions: they only answer
-            # once enabled on the account. Skip them instead of failing the whole
-            # nightly run (and paging #infraex on Slack) while enablement is
-            # pending. Mirrors the guard in permanent_resources_audit.yml.
-            - name: Check region accessibility
+            # Some of the regions above are AWS opt-in regions: they cannot be
+            # used until the account opts in. Skip those instead of failing the
+            # whole nightly run (and paging #infraex on Slack) while enablement
+            # is pending.
+            #
+            # The opt-in status is read authoritatively from DescribeRegions
+            # rather than inferred from the error text of a call to the region
+            # itself. Matching error strings would also swallow generic
+            # credential and permission failures (AuthFailure, AccessDenied,
+            # InvalidClientTokenId), silently skipping the cleanup and leaking
+            # resources behind a green run.
+            #
+            # The query is issued against a region that is enabled by default,
+            # so a broken credential fails the call — and therefore the step —
+            # instead of being misread as "region disabled".
+            - name: Check region opt-in status
               if: ${{ env.should_run == 'true' }}
+              env:
+                  # Enabled by default (launched before March 2019), so it always
+                  # answers as long as the credentials are valid.
+                  QUERY_REGION: eu-west-2
               run: |
                   REGION="${{ env.AWS_REGION }}"
-                  if OUTPUT=$(aws ec2 describe-availability-zones --region "$REGION" 2>&1); then
-                      echo "✅ Region $REGION is accessible"
-                      exit 0
-                  fi
-                  if echo "$OUTPUT" | grep -qiE 'UnauthorizedOperation|AuthFailure|OptInRequired|InvalidClientTokenId|AccessDenied|not enabled|not subscribed'; then
-                      echo "⏭️ Region $REGION is not enabled on this account (opt-in required). Skipping its cleanup."
-                      echo "should_run=false" | tee -a "$GITHUB_ENV"
-                      exit 0
-                  fi
-                  echo "❌ Unexpected error checking region $REGION:"
-                  echo "$OUTPUT"
-                  exit 1
+
+                  # Fails the step on a credential or permission error, which is
+                  # the behaviour we want: a cleanup that cannot run must be
+                  # loud, not silently skipped.
+                  OPT_STATUS=$(aws ec2 describe-regions \
+                      --region "$QUERY_REGION" \
+                      --all-regions \
+                      --region-names "$REGION" \
+                      --query 'Regions[0].OptInStatus' \
+                      --output text)
+
+                  case "$OPT_STATUS" in
+                      opted-in|opt-in-not-required)
+                          echo "✅ Region $REGION is enabled ($OPT_STATUS)"
+                          ;;
+                      not-opted-in)
+                          echo "⏭️ Region $REGION is not enabled on this account ($OPT_STATUS). Skipping its cleanup."
+                          echo "should_run=false" | tee -a "$GITHUB_ENV"
+                          ;;
+                      *)
+                          echo "❌ Unexpected opt-in status for $REGION: '$OPT_STATUS'" >&2
+                          exit 1
+                          ;;
+                  esac
 
             - name: Install Cloud Nuke
               if: ${{ env.should_run == 'true' }}

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -240,6 +240,17 @@ jobs:
                           echo "✅ Region $REGION is enabled ($OPT_STATUS)"
                           ;;
                       not-opted-in)
+                          # Skipping rather than failing keeps a newly added
+                          # opt-in region from breaking the nightly run before
+                          # it is enabled.
+                          #
+                          # It is still surfaced as a warning, because the other
+                          # way to reach this state is a region that WAS enabled
+                          # being disabled again — and a disabled region keeps
+                          # billing for resources that are now unreachable and
+                          # no longer swept. That must not hide behind a green
+                          # run.
+                          echo "::warning title=Region $REGION not enabled::Skipping cleanup for $REGION ($OPT_STATUS). If this region is expected to be enabled, resources in it are no longer being swept and keep incurring charges."
                           echo "⏭️ Region $REGION is not enabled on this account ($OPT_STATUS). Skipping its cleanup."
                           echo "should_run=false" | tee -a "$GITHUB_ENV"
                           ;;

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -107,7 +107,7 @@ jobs:
                       cleanup_older_than: 12h
                     # Third CI region, used by the multi-region reference
                     # architectures that need more than two regions to keep a
-                    # Raft quorum. Opt-in region: see the accessibility guard below.
+                    # Raft quorum. Opt-in region: see the opt-in status guard below.
                     - region: eu-central-2
                       day: All
                       cleanup_older_than: 12h
@@ -115,7 +115,8 @@ jobs:
                       day: Saturday
                       cleanup_older_than: 0h
                     # Fourth region available to multi-region work, kept weekly so
-                    # a topology can survive a work week. Opt-in region.
+                    # a topology can survive a work week. Opt-in region: see the opt-in
+                    # status guard below.
                     - region: eu-south-1
                       day: Saturday
                       cleanup_older_than: 0h

--- a/.github/workflows/permanent_resources_audit.yml
+++ b/.github/workflows/permanent_resources_audit.yml
@@ -35,7 +35,7 @@ env:
     SLACK_MENTION: ${{ github.event_name != 'pull_request' && '<!subteam^S06NTRBMWUD> please' || 'Please' }}
 
     # Regions excluded from permanent audit as they are cleaned daily or weekly (see README.md)
-    AWS_EXCLUDED_REGIONS: '["eu-west-2", "eu-west-3", "eu-north-1", "us-east-1", "us-east-2"]'
+    AWS_EXCLUDED_REGIONS: '["eu-west-2", "eu-west-3", "eu-central-2", "eu-north-1", "eu-south-1", "us-east-1", "us-east-2"]'
     AZURE_EXCLUDED_REGIONS: '["swedencentral", "spaincentral"]'
 
     # ELBv2 target group quota headroom audit thresholds. cloud-nuke does not

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ CI Regions are designated specifically for **Continuous Integration (CI) tests**
 |------------|------------|------------------|
 | EU (London)| eu-west-2  | Daily @5AM       |
 | EU (Paris) | eu-west-3  | Daily @5AM       |
+| EU (Zurich)| eu-central-2 | Daily @5AM     |
+
+`eu-central-2` is the third daily region, added for the multi-region reference architectures: three regions is the smallest topology where a Camunda Zeebe cluster keeps its Raft quorum after losing one region.
+
+> [!IMPORTANT]
+> `eu-central-2` is an AWS **opt-in** region and must be enabled on the account before it is usable. Until it is, the nightly cleanup detects that it is not accessible and skips it instead of failing.
 
 ##### Azure Regions
 
@@ -50,8 +56,14 @@ To keep the environment organized, all resources in these regions are automatica
 | Region              | Identifier   | Cleanup Schedule |
 |---------------------|--------------|------------------|
 | EU (Stockholm)      | eu-north-1   | Saturday @5AM    |
+| EU (Milan)          | eu-south-1   | Saturday @5AM    |
 | US East (N. Virginia) | us-east-1 | Saturday @5AM    |
 | US East (Ohio) | us-east-2 | Saturday @5AM    |
+
+`eu-south-1` gives multi-region work a fourth region that survives a work week.
+
+> [!IMPORTANT]
+> `eu-south-1` is an AWS **opt-in** region and must be enabled on the account before it is usable. Until it is, the weekly cleanup detects that it is not accessible and skips it instead of failing.
 
 ##### Azure Regions
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ CI Regions are designated specifically for **Continuous Integration (CI) tests**
 
 `eu-central-2` is the third daily region, added for the multi-region reference architectures: three regions is the smallest topology where a Camunda Zeebe cluster keeps its Raft quorum after losing one region.
 
-> [!IMPORTANT]
-> `eu-central-2` is an AWS **opt-in** region and must be enabled on the account before it is usable. Until it is, the nightly cleanup detects that it is not accessible and skips it instead of failing.
-
 ##### Azure Regions
 
 | Region         | Identifier   | Cleanup Schedule       |
@@ -62,15 +59,20 @@ To keep the environment organized, all resources in these regions are automatica
 
 `eu-south-1` gives multi-region work a fourth region that survives a work week.
 
-> [!IMPORTANT]
-> `eu-south-1` is an AWS **opt-in** region and must be enabled on the account before it is usable. Until it is, the weekly cleanup detects that it is not accessible and skips it instead of failing.
-
 ##### Azure Regions
 
 | Region         | Identifier   | Cleanup Schedule          |
 |----------------|--------------|-------------------------|
 | Spain Central  | spaincentral | Saturday @5AM     |
 
+
+#### Opt-in Regions
+
+`eu-central-2` (Zurich) and `eu-south-1` (Milan) are AWS **opt-in** regions: regions launched after 20 March 2019 are disabled by default and must be enabled on the account before anything can be created in them. Every other region above predates that cutoff and is enabled by default, which AWS does not allow to be disabled.
+
+Both are enabled, declared in [infraex-terraform `aws/regions.tf`](https://github.com/camunda/infraex-terraform/blob/main/aws/regions.tf) rather than clicked in the console, so the nightly drift detection notices if one is turned off again.
+
+Before adding another opt-in region to a cleanup schedule, enable it there first. The cleanup skips a region that is not opted in — with a warning annotation — instead of failing the whole run, so the ordering is forgiving, but a region left disabled is not being swept and its resources keep incurring charges.
 
 #### Permanent Regions
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To keep the environment organized, all resources in these regions are automatica
 
 Both are enabled, declared in [infraex-terraform `aws/regions.tf`](https://github.com/camunda/infraex-terraform/blob/main/aws/regions.tf) rather than clicked in the console, so the nightly drift detection notices if one is turned off again.
 
-Before adding another opt-in region to a cleanup schedule, enable it there first. The cleanup skips a region that is not opted in — with a warning annotation — instead of failing the whole run, so the ordering is forgiving, but a region left disabled is not being swept and its resources keep incurring charges.
+Enable an opt-in region there **before** adding it to a cleanup schedule. The cleanup does not tolerate a region it cannot reach: it fails loudly, which is deliberate. A region that stops being reachable is not being swept, and a disabled region keeps incurring charges for resources that are no longer visible — that must page someone, not degrade quietly.
 
 #### Permanent Regions
 


### PR DESCRIPTION
## Motivation

Multi-region reference architectures need more than two regions. Three is the smallest topology where a Camunda Zeebe cluster **keeps its Raft quorum after losing a region**: with one replica per region, a partition keeps its majority while `N-1 > N/2`, which holds for every `N >= 3`. With two regions there is no assignment that survives losing half of it, which is why the dual-region architecture halts on a region loss and needs a failover procedure.

Driven by camunda/camunda-deployment-references#2940, which adds `aws/kubernetes/eks-multi-region-rdbms`.

## Changes

**`eu-central-2` (Zurich) → daily CI region.** Third region alongside eu-west-2 and eu-west-3. RTT ~20 ms to London, ~15 ms to Paris, comfortably inside the 100 ms Camunda budget.

**`eu-south-1` (Milan) → weekly work region.** A fourth region for multi-region work that must survive a work week, alongside eu-north-1 / us-east-1 / us-east-2.

**No guard, deliberately.** An earlier revision of this PR added a step that skipped a region which was not opted in, so the PR could be merged before the regions were enabled. They are enabled now, so that precondition is gone and the step has been removed — the workflow change is just the two matrix entries.

Keeping it would have been wrong anyway. Its only remaining effect was turning a hard failure into a soft skip, and for the case that matters from here — a region that **was** enabled being disabled again — the hard failure is correct: `aws_regional_cleanup.sh` runs `set -euxo pipefail` and the strict cloud-nuke pass has no `continue-on-error`, so an unreachable region fails the job and pages. A region that is not being swept accrues cost on resources nobody can see; that should be loud.

The remaining scenario — adding a new opt-in region to the matrix before enabling it — is a one-run mistake with an obvious error, and the README now states the correct order. Optimising for doing it backwards was not worth a step that had already carried one real bug (it matched `AuthFailure` / `AccessDenied` / `InvalidClientTokenId`, so a broken credential would have silently skipped the cleanup behind a green run — caught by Copilot in review).

**Permanent resources audit.** Both regions added to `AWS_EXCLUDED_REGIONS`: they are now cleaned on a schedule and must not be reported as permanent.

**Aurora Global Database teardown: no change needed.** `aws-global-db-teardown` derives its region list from the cleanup matrix, so it picks the new regions up automatically. Verified:

```
CLEANUP_REGIONS:          eu-west-2 eu-west-3 eu-central-2 eu-north-1 eu-south-1 us-east-1 us-east-2
ACTIVE_REGIONS (Monday):  eu-west-2 eu-west-3 eu-central-2
ACTIVE_REGIONS (Saturday):eu-west-2 eu-west-3 eu-central-2 eu-north-1 eu-south-1 us-east-1 us-east-2
```

That matters for the multi-region architecture: it creates Aurora Global Databases spanning several of these regions, and the teardown only touches a global database whose members **all** live in wiped regions. Adding eu-central-2 is what makes those clusters eligible.

**README** updated with both tables and a single Opt-in Regions section stating the durable facts: which regions are opt-in, that the rest predate the March 2019 cutoff and cannot be disabled, and that the opt-in is declared in Terraform.

## Status

`eu-central-2` and `eu-south-1` are **enabled and verified working**. camunda/infraex-terraform#398 is merged and applied (`Terraform apply: 2 added, 0 changed, 0 destroyed`), and the latest run of this PR's cleanup workflow shows:

```
✅ Region eu-central-2 is enabled (opted-in)            → full cleanup ran, all steps success
✅ Region eu-south-1   is enabled (opted-in)            → full cleanup ran, all steps success
✅ Region eu-west-2    is enabled (opt-in-not-required) → unchanged
```

No IT action was needed in the end: the CI credentials already carried `account:EnableRegion`.

Enablement is asynchronous — an earlier run 40 minutes after the merge still reported the regions as unusable, which is exactly the window the guard exists to cover.

## Validation

- `pre-commit run` green (`actionlint`, `yamlfmt`, whitespace, EOF)
- `yq` matrix derivation checked against the new matrix for both a weekday and Saturday
- Guard regex reused verbatim from `permanent_resources_audit.yml`, already in production


