### PR TITLE
fix(aws-cleanup): fail the nightly sweep when cloud-nuke cannot list resources

### DIFF
--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -279,7 +279,28 @@ jobs:
                   --exclude-resource-type cloudtrail \
                   --exclude-resource-type ec2-keypairs \
                   --exclude-resource-type guard-duty \
-                  --exclude-resource-type s3
+                  --exclude-resource-type s3 \
+                  2>&1 | tee cloud-nuke-strict.log
+
+            # cloud-nuke exits 0 when it cannot even *list* a resource type, so a
+            # region we are no longer allowed to reach reports "Nothing to nuke,
+            # you're all good!" and this job goes green while sweeping nothing.
+            # A revoked IAM permission, an Organizations SCP, expired credentials,
+            # a disabled region or a partial outage all produce that same silent
+            # success, and whatever the sweep failed to delete keeps costing money
+            # with nobody told. The strict run is meant to be the gate, so make it
+            # actually gate.
+            - name: Assert Cloud Nuke could enumerate resources
+              if: ${{ env.should_run == 'true' }}
+              run: |
+                  # Both markers come from cloud-nuke's own per-resource-type report:
+                  #   | vpc | Unable to retrieve vpc | vpc: failed to list resources in eu-central-2
+                  if grep -nE 'failed to list resources|Unable to retrieve' cloud-nuke-strict.log; then
+                      echo "::error title=Cloud Nuke could not enumerate resources in ${{ env.AWS_REGION }}::The sweep exited 0 but could not list the resource types reported above, so this region was not cleaned. Check the credentials, the IAM permissions and any Organizations SCP covering the region."
+                      exit 1
+                  fi
+
+                  echo "cloud-nuke enumerated every resource type in ${{ env.AWS_REGION }}."
 
     notify-on-failure:
         runs-on: ubuntu-latest

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -247,6 +247,11 @@ jobs:
             # killing the step, unlike a shell-level `|| true`).
             # We're ignoring ec2-dhcp-option as they couldn't be deleted
             # cloudtrail is managed by IT and can't be deleted either
+            # macie-member and ses-receipt-filter do not exist in every region
+            # (Macie and SES receipt rules are not offered in eu-central-2, for
+            # one), so cloud-nuke cannot list them there. We never create either,
+            # so excluding them costs no coverage and keeps the enumeration check
+            # below meaningful: it can then treat *any* listing failure as real.
             - name: Run Cloud Nuke (best-effort)
               timeout-minutes: 90
               continue-on-error: true
@@ -261,7 +266,9 @@ jobs:
                   --exclude-resource-type ec2-dhcp-option \
                   --exclude-resource-type ec2-keypairs \
                   --exclude-resource-type guard-duty \
+                  --exclude-resource-type macie-member \
                   --exclude-resource-type s3 \
+                  --exclude-resource-type ses-receipt-filter \
                   --exclude-resource-type cloudtrail
 
             # The second run should remove the remaining resources (VPCs) and fail if there's anything left
@@ -279,7 +286,9 @@ jobs:
                   --exclude-resource-type cloudtrail \
                   --exclude-resource-type ec2-keypairs \
                   --exclude-resource-type guard-duty \
+                  --exclude-resource-type macie-member \
                   --exclude-resource-type s3 \
+                  --exclude-resource-type ses-receipt-filter \
                   2>&1 | tee cloud-nuke-strict.log
 
             # cloud-nuke exits 0 when it cannot even *list* a resource type, so a


### PR DESCRIPTION
## What

`cloud-nuke` exits 0 when it cannot enumerate a resource type. A region the sweep can no longer reach therefore reports `Nothing to nuke, you're all good!` and the job goes green while deleting nothing — indistinguishable from a genuinely clean region.

`Run Cloud Nuke (strict)` carries no `continue-on-error`, so the assumption has been that a broken sweep fails the job. It does not. The gate does not gate.

The strict run now tees its output, and a following step fails on cloud-nuke's own listing-failure markers.

## Why it matters beyond the region that surfaced it

Any cause of a listing failure produces the same silent success:

- a revoked IAM permission or an Organizations SCP change
- expired or rotated credentials
- a region being disabled
- a partial AWS outage

In every case the cleanup quietly stops working, resources accumulate, and they keep incurring charges. That is precisely the outcome the nightly job exists to prevent.

## Evidence

Measured against the nightly run of 2026-08-04 (`30882300514`), while an Organizations SCP still denied `eu-central-2`:

| Region | Lines matching the markers | cloud-nuke verdict | Job result before this PR |
|---|---|---|---|
| `eu-central-2` | **440** | `Nothing to nuke, you're all good!` | success |
| `eu-west-2` | **0** | `Nothing to nuke, you're all good!` | success |

So the check fires on the broken region and stays quiet on the healthy one, which is the pair of properties that matters:

- a region that could not be enumerated now **fails**
- a genuinely empty region still **passes**, so the signal stays useful

The markers are cloud-nuke's own per-resource-type report:

```
| vpc            | Unable to retrieve vpc            | vpc: failed to list resources in eu-central-2
| security-group | Unable to retrieve security-group | security-group: failed to list resources
```

## Implementation choice

Two options were on the table in the issue. This is the post-check on the sweep output rather than a pre-flight probe, because it validates the actual sweep instead of a proxy for it and catches every cause of a listing failure rather than only what the probe happens to touch.

Only the strict run is checked. The best-effort run is expected to fail and already carries `continue-on-error: true`.

## Note on timing

The SCP that produced the evidence above was lifted by IT earlier today (camunda/team-infrastructure-experience#1199), so this PR's own dry-run should now be green in every region, `eu-central-2` and `eu-south-1` included. The defect is unrelated to that policy and remains fixed here.

Closes #1201

## Follow-up found by this PR's own CI

The first run of the check failed on `eu-central-2` for two resource types:

```
Unable to retrieve macie-member, macie-member: failed to list resources in eu-central-2:
  operation error Macie2: GetMacieSession
Unable to retrieve ses-receipt-filter, ses-receipt-filter: failed to list resources in eu-central-2:
  operation error SES: ListReceiptFilters
```

Neither is an access problem. Macie and SES receipt rules are simply not offered in that region, so cloud-nuke cannot list them there and never will. Left alone this would paint the nightly red in `eu-central-2` every single night and train everyone to ignore it — the exact failure mode the check exists to prevent.

Both are now excluded from the sweep, which keeps the assertion absolute: any listing failure that remains is a real one. No coverage is lost, since CI creates neither resource type. Same reasoning that already excludes `guard-duty` and `cloudtrail`.

Worth noting that the check earned its keep before it even merged: it surfaced a region-specific gap that the previous "always green" behaviour had been hiding.
