### PR TITLE
feat(renovate): register custom.aurora-mysql-camunda datasource

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -155,6 +155,7 @@
       matchPackageNames: [
         'amazon-eks',
         'amazon-rds-postgresql',
+        'aurora-mysql',
         'aurora-postgresql',
         'ghcr.io/cloudnative-pg/postgresql',
         'opensearch',
@@ -167,7 +168,7 @@
       draftPR: true,
       prBodyNotes: [
         '⚠️ **Breaking Changes Possible** ⚠️',
-        "This update includes a new major version of a core infrastructure component (Amazon EKS, OpenSearch, OpenShift, or a PostgreSQL engine/image). See this rule's `matchPackageNames` for the exact set.",
+        "This update includes a new major version of a core infrastructure component (Amazon EKS, OpenSearch, OpenShift, or a PostgreSQL/MySQL engine/image). See this rule's `matchPackageNames` for the exact set.",
         'Such updates typically introduce breaking changes and are only applied **at the beginning of a Camunda 8 release cycle**.',
         'This update **should not** be merged mid-cycle unless explicitly approved by yourself.',
       ],
@@ -298,6 +299,10 @@
     },
     'aurora-pg-camunda': {
       'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/aurora_postgres_versions.txt',
+      'format': 'plain',
+    },
+    'aurora-mysql-camunda': {
+      'defaultRegistryUrlTemplate': 'https://camunda.github.io/camunda-deployment-references/aurora_mysql_versions.txt',
       'format': 'plain',
     },
     // Bitnami Premium image tags published by camunda-deployment-references, one


### PR DESCRIPTION
## Why

`aws/modules/aurora-global` (in `camunda-deployment-references`) pins its Aurora MySQL engine version with a `datasource=custom.aurora-mysql-camunda` Renovate annotation, but that custom datasource was never registered here — so the annotation is inert and the MySQL pin is never bumped, unlike every other `custom.*` datasource.

## What

- Register the `aurora-mysql-camunda` custom datasource (pointing at `aurora_mysql_versions.txt`), mirroring the existing `aurora-pg-camunda` entry.
- Add `aurora-mysql` to the major-bump breaking-change guard so an Aurora MySQL major upgrade gets a draft PR + warning instead of silently falling through to the grouped minor/patch rules.

Validated with `renovate-config-validator --strict` (passes). Refs camunda/team-infrastructure-experience#1209.

> Follow-ups tracked in the issue live in `camunda-deployment-references` (publish `aurora_mysql_versions.txt`, fix the `versioning=regex:` in `variables.tf`, drop the TODO) and are handled separately.
