### PR TITLE
fix(aws-cleanup): stop the sweep from breaking live clusters, and drain the Route53 leak

### DIFF
--- a/.github/config/permanent_resources_allowlist.yml
+++ b/.github/config/permanent_resources_allowlist.yml
@@ -9,10 +9,13 @@ aws:
     # approved bucket here, regardless of the region it physically lives in.
     global:
         # S3 buckets
+        #
+        # Keep in sync with the canonical keeplist consumed by aws_global_cleanup.sh:
+        # https://github.com/camunda/infraex-terraform/blob/main/aws/s3-buckets.yml
+        # A bucket listed here but absent from that file is still deleted by the
+        # weekly global cleanup, so the audit would keep reporting it as missing.
         s3:
             - general-purpose-bucket-that-will-not-be-deleted
-            - infraex-terraform-state
-            - infraex-artifacts
             - tests-eks-tf-state-eu-central-1
             - tests-c8-multi-region-es-eu-central-1
             - tests-rosa-tf-state-eu-central-1

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -19,6 +19,7 @@ on:
             - .github/workflows/scripts/aws_global_cleanup.sh
             - .github/workflows/scripts/aws_global_db_teardown.sh
             - .github/workflows/scripts/aws_regional_cleanup.sh
+            - .github/workflows/scripts/aws_route53_cleanup.sh
 
 env:
     AWS_PROFILE: infraex
@@ -215,6 +216,16 @@ jobs:
               timeout-minutes: 15
               if: ${{ env.should_run == 'true' }}
               run: .github/workflows/scripts/aws_regional_cleanup.sh "${{ env.AWS_REGION }}"
+
+            # Runs before cloud-nuke, so the load balancers of the environment being
+            # torn down tonight are still alive and their records are kept. cloud-nuke
+            # removes those load balancers below, and tomorrow's run deletes the
+            # records. Orphans therefore drain with a one-day lag, like the orphaned
+            # target groups handled in aws_regional_cleanup.sh.
+            - name: Delete orphaned Route53 records
+              timeout-minutes: 20
+              if: ${{ env.should_run == 'true' }}
+              run: .github/workflows/scripts/aws_route53_cleanup.sh "${{ env.AWS_REGION }}"
 
             # this token is used to clone the github repository containing the base modules
             - name: Generate token for GitHub

--- a/.github/workflows/scripts/aws_regional_cleanup.sh
+++ b/.github/workflows/scripts/aws_regional_cleanup.sh
@@ -7,6 +7,18 @@ set -euxo pipefail
 # Default value for DRY_RUN is false
 DRY_RUN=${DRY_RUN:-false}
 
+# Resources younger than this window are left alone.
+#
+# cloud-nuke runs *after* this script in the same job with the same window and
+# deliberately spares resources younger than it. This script must honour the same
+# window, otherwise it deletes the dependencies of a cluster cloud-nuke is about
+# to keep: the cluster stays up but silently loses IRSA (every pod using a
+# service-account role stops getting credentials) with no error surfaced anywhere.
+#
+# Same value as the cloud-nuke `--older-than` flag, e.g. "12h". "0h" disables the
+# filter (weekly regions, where everything is expected to go).
+CLEANUP_OLDER_THAN="${CLEANUP_OLDER_THAN:-0h}"
+
 # Check if the region argument is provided
 if [ -z "$1" ]; then
     echo "Please provide the AWS region as the first argument."
@@ -14,6 +26,13 @@ if [ -z "$1" ]; then
 fi
 
 region="$1"
+
+cleanup_older_than_hours="${CLEANUP_OLDER_THAN%h}"
+if ! [[ "$cleanup_older_than_hours" =~ ^[0-9]+$ ]]; then
+    echo "CLEANUP_OLDER_THAN must be a number of hours such as '12h' (got '$CLEANUP_OLDER_THAN')."
+    exit 1
+fi
+age_cutoff_epoch=$(( $(date -u +%s) - cleanup_older_than_hours * 3600 ))
 
 echo "Deleting additional resources in the $region region..."
 
@@ -58,6 +77,79 @@ paginate() {
     done
 }
 
+# Converts an ISO-8601 timestamp to epoch seconds, or prints nothing if it cannot
+# be parsed. AWS returns both offset-aware ("...+02:00", "...Z") and naive
+# ("2026-08-06T14:39:35", always UTC) forms depending on the API, so naive values
+# are pinned to UTC rather than to the runner's local timezone.
+# python3 is used instead of `date` because GNU and BSD date disagree on both
+# parsing and epoch formatting, and this script runs on CI and on laptops.
+iso_to_epoch() {
+    python3 -c '
+import sys, datetime
+try:
+    parsed = datetime.datetime.fromisoformat(sys.argv[1].strip().replace("Z", "+00:00"))
+except ValueError:
+    sys.exit(0)
+if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+print(int(parsed.timestamp()))
+' "$1" 2>/dev/null || true
+}
+
+# Returns 0 when a resource created at $1 (epoch seconds) is old enough to delete.
+# An unknown timestamp fails closed and keeps the resource: a missed deletion is
+# picked up by the next nightly run, a wrong deletion is not recoverable.
+is_old_enough() {
+    local created_epoch="$1"
+
+    # No window configured: age is irrelevant, everything is in scope.
+    if [ "$cleanup_older_than_hours" -eq 0 ]; then
+        return 0
+    fi
+    if [ -z "$created_epoch" ]; then
+        return 1
+    fi
+
+    [ "$created_epoch" -le "$age_cutoff_epoch" ]
+}
+
+# EKS clusters that still exist in this region, and the OIDC issuer id of each.
+# These are the clusters cloud-nuke will keep (too young) or has not reached yet;
+# their OIDC provider and control-plane log group must survive with them.
+live_eks_clusters=$(aws eks list-clusters --region "$region" --query 'clusters[]' --output text 2>/dev/null || true)
+
+live_oidc_ids=""
+for live_cluster in $live_eks_clusters; do
+    cluster_issuer=$(aws eks describe-cluster --region "$region" --name "$live_cluster" \
+        --query 'cluster.identity.oidc.issuer' --output text 2>/dev/null || true)
+    if [ -n "$cluster_issuer" ] && [ "$cluster_issuer" != "None" ]; then
+        # Issuer looks like https://oidc.eks.<region>.amazonaws.com/id/<ID>
+        live_oidc_ids="$live_oidc_ids ${cluster_issuer##*/}"
+    fi
+done
+
+# Returns 0 when $1 mentions the name of an EKS cluster that still exists.
+# Some resources (VPC peering connections) expose no creation timestamp at all in
+# the AWS API, so their Name tag is the only signal available. Best-effort by
+# design: it only ever keeps more resources than the age filter would.
+references_live_cluster() {
+    local haystack="$1"
+    local candidate
+
+    if [ -z "$haystack" ] || [ "$haystack" = "None" ]; then
+        return 1
+    fi
+    for candidate in $live_eks_clusters; do
+        if [[ "$haystack" == *"$candidate"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+echo "Age filter: keeping resources newer than ${cleanup_older_than_hours}h"
+echo "Live EKS clusters in $region: ${live_eks_clusters:-<none>}"
+
 echo "Deleting OIDC Providers"
 # Delete OIDC Provider
 oidc_providers=$(paginate "aws iam list-open-id-connect-providers" "OpenIDConnectProviderList[?contains(Arn, '$region')].Arn")
@@ -67,6 +159,22 @@ if [ -n "$oidc_providers" ]; then
 
     for oidc_provider in "${oidc_providers_array[@]}"
     do
+        # An OIDC provider whose EKS cluster is still alive is load-bearing:
+        # removing it breaks IRSA instantly for every pod on that cluster.
+        oidc_id="${oidc_provider##*/}"
+        if [[ " $live_oidc_ids " == *" $oidc_id "* ]]; then
+            echo "Skipping OIDC Provider: $oidc_provider (its EKS cluster still exists)"
+            continue
+        fi
+
+        oidc_created=$(aws iam get-open-id-connect-provider \
+            --open-id-connect-provider-arn "$oidc_provider" \
+            --query 'CreateDate' --output text 2>/dev/null || true)
+        if ! is_old_enough "$(iso_to_epoch "$oidc_created")"; then
+            echo "Skipping OIDC Provider: $oidc_provider (created $oidc_created, too recent)"
+            continue
+        fi
+
         echo "Deleting OIDC Provider: $oidc_provider"
         execute_or_simulate "aws iam delete-open-id-connect-provider --open-id-connect-provider-arn $oidc_provider"
     done
@@ -81,6 +189,18 @@ if [ -n "$peering_connection_ids" ]; then
 
     for peering_connection_id in "${peering_connection_ids_array[@]}"
     do
+        # Dual-region tests peer the VPC of two live clusters. The EC2 API exposes
+        # no creation time for a peering connection, so fall back to its Name tag:
+        # tearing this down mid-test breaks cross-region connectivity.
+        peering_name=$(aws ec2 describe-vpc-peering-connections --region "$region" \
+            --vpc-peering-connection-ids "$peering_connection_id" \
+            --query "VpcPeeringConnections[0].Tags[?Key==\`Name\`].Value | [0]" \
+            --output text 2>/dev/null || true)
+        if references_live_cluster "$peering_name"; then
+            echo "Skipping VPC Peering Connection: $peering_connection_id ($peering_name references a live cluster)"
+            continue
+        fi
+
         echo "Deleting VPC Peering Connection: $peering_connection_id"
         execute_or_simulate "aws ec2 delete-vpc-peering-connection --region $region --vpc-peering-connection-id $peering_connection_id"
     done
@@ -96,6 +216,24 @@ if [ -n "$client_vpn_endpoint_ids" ]; then
     for cvpn_id in "${client_vpn_ids_array[@]}"
     do
         echo "Processing Client VPN Endpoint: $cvpn_id"
+
+        cvpn_details=$(aws ec2 describe-client-vpn-endpoints --region "$region" \
+            --client-vpn-endpoint-ids "$cvpn_id" \
+            --query "ClientVpnEndpoints[0].[CreationTime,Tags[?Key==\`Name\`].Value|[0]]" \
+            --output text 2>/dev/null || true)
+        cvpn_created=$(echo "$cvpn_details" | cut -f1)
+        cvpn_name=$(echo "$cvpn_details" | cut -f2)
+
+        # A Client VPN endpoint is how engineers reach a private cluster. Removing
+        # one that belongs to a cluster still running cuts access to a live test.
+        if references_live_cluster "$cvpn_name"; then
+            echo "Skipping Client VPN Endpoint: $cvpn_id ($cvpn_name references a live cluster)"
+            continue
+        fi
+        if ! is_old_enough "$(iso_to_epoch "$cvpn_created")"; then
+            echo "Skipping Client VPN Endpoint: $cvpn_id (created $cvpn_created, too recent)"
+            continue
+        fi
 
         # Disassociate target networks
         associations=$(aws ec2 describe-client-vpn-target-networks \
@@ -146,8 +284,16 @@ if [ -n "$user_pool_ids" ]; then
     do
         echo "Processing Cognito User Pool: $user_pool_id"
 
-        # Get and delete the domain first (required before deleting the User Pool)
-        domain=$(aws cognito-idp describe-user-pool --region "$region" --user-pool-id "$user_pool_id" --query 'UserPool.Domain' --output text 2>/dev/null || true)
+        # Domain and creation date come from the same call: the domain must be
+        # deleted before the pool, the date decides whether we touch it at all.
+        user_pool_details=$(aws cognito-idp describe-user-pool --region "$region" --user-pool-id "$user_pool_id" --query 'UserPool.[Domain,CreationDate]' --output text 2>/dev/null || true)
+        domain=$(echo "$user_pool_details" | cut -f1)
+        user_pool_created=$(echo "$user_pool_details" | cut -f2)
+
+        if ! is_old_enough "$(iso_to_epoch "$user_pool_created")"; then
+            echo "Skipping Cognito User Pool: $user_pool_id (created $user_pool_created, too recent)"
+            continue
+        fi
 
         if [ -n "$domain" ] && [ "$domain" != "None" ]; then
             echo "Deleting Cognito User Pool Domain: $domain"
@@ -182,6 +328,13 @@ if [ -n "$cert_arns" ]; then
 
     for cert_arn in "${cert_arns_array[@]}"
     do
+        cert_created=$(aws acm describe-certificate --region "$region" --certificate-arn "$cert_arn" \
+            --query 'Certificate.CreatedAt' --output text 2>/dev/null || true)
+        if ! is_old_enough "$(iso_to_epoch "$cert_created")"; then
+            echo "Skipping ACM Certificate: $cert_arn (created $cert_created, too recent)"
+            continue
+        fi
+
         echo "Deleting ACM Certificate: $cert_arn"
         # Note: This will fail if the certificate is in use by another AWS resource
         execute_or_simulate "aws acm delete-certificate --region $region --certificate-arn $cert_arn" || true
@@ -218,16 +371,26 @@ fi
 echo "Deleting unattached Elastic IPs"
 # Delete Elastic IPs that are not associated with any instance or network interface
 # Unattached EIPs cost ~$3.65/month each
-eip_allocations=$(aws ec2 describe-addresses --region "$region" --query 'Addresses[?!AssociationId].AllocationId' --output text || true)
+eip_allocations=$(aws ec2 describe-addresses --region "$region" --query "Addresses[?!AssociationId].[AllocationId,Tags[?Key==\`Name\`].Value|[0]]" --output text || true)
 
 if [ -n "$eip_allocations" ]; then
-    read -r -a eip_allocations_array <<< "$eip_allocations"
-
-    for allocation_id in "${eip_allocations_array[@]}"
+    while IFS=$'\t' read -r allocation_id eip_name
     do
+        if [ -z "$allocation_id" ]; then
+            continue
+        fi
+
+        # An EIP has no creation timestamp in the EC2 API. The Name tag is the
+        # only way to tell an address orphaned by a destroyed cluster from one a
+        # live cluster has allocated but not yet associated.
+        if references_live_cluster "$eip_name"; then
+            echo "Skipping Elastic IP: $allocation_id ($eip_name references a live cluster)"
+            continue
+        fi
+
         echo "Releasing Elastic IP: $allocation_id"
         execute_or_simulate "aws ec2 release-address --region $region --allocation-id $allocation_id"
-    done
+    done <<< "$eip_allocations"
 fi
 
 echo "Deleting CloudWatch Log Groups"
@@ -235,15 +398,35 @@ echo "Deleting CloudWatch Log Groups"
 # ephemeral test regions, where log groups left behind by deleted resources
 # (EKS control-plane, ECS Container Insights, VPC flow logs, ECS task logs, ...)
 # should be cleaned up too. Only skip those explicitly marked DO_NOT_DELETE.
-log_groups=$(paginate "aws logs describe-log-groups --region $region" "logGroups[].logGroupName")
+# Name and creation time are fetched together: a log group is skipped when it
+# belongs to a cluster that is still running (deleting the control-plane log
+# group of a live cluster destroys the only trace of what it is doing) or when
+# it is younger than the cleanup window. `creationTime` is in milliseconds.
+log_groups=$(paginate "aws logs describe-log-groups --region $region" "logGroups[].[logGroupName,creationTime]")
 
 if [ -n "$log_groups" ]; then
-    read -r -a log_groups_array <<< "$log_groups"
-
-    for log_group in "${log_groups_array[@]}"
+    while IFS=$'\t' read -r log_group log_group_created_ms
     do
+        if [ -z "$log_group" ]; then
+            continue
+        fi
+
         if [[ "$log_group" == *DO_NOT_DELETE* ]]; then
             echo "Skipping log group: $log_group (protected)"
+            continue
+        fi
+
+        if references_live_cluster "$log_group"; then
+            echo "Skipping log group: $log_group (references a live cluster)"
+            continue
+        fi
+
+        log_group_created_epoch=""
+        if [[ "$log_group_created_ms" =~ ^[0-9]+$ ]]; then
+            log_group_created_epoch=$(( log_group_created_ms / 1000 ))
+        fi
+        if ! is_old_enough "$log_group_created_epoch"; then
+            echo "Skipping log group: $log_group (too recent)"
             continue
         fi
 
@@ -251,7 +434,7 @@ if [ -n "$log_groups" ]; then
         # Best-effort: a genuinely undeletable / service-managed log group must
         # not abort the rest of the cleanup (set -e).
         execute_or_simulate "aws logs delete-log-group --region $region --log-group-name \"$log_group\"" || true
-    done
+    done <<< "$log_groups"
 fi
 
 echo "Deleting orphaned ELBv2 Target Groups"
@@ -274,6 +457,14 @@ echo "Deleting orphaned ELBv2 Target Groups"
 # leaving a large backlog to drain 400 at a time. Deletions run in parallel:
 # a leaked backlog can be thousands of target groups, far more than a sequential
 # loop can delete within this step's time budget.
+#
+# No age filter here: ELBv2 exposes no creation timestamp for a target group, and
+# resolving each one's owning cluster would cost one describe-tags call per target
+# group, which the backlog size above rules out. `LoadBalancerArns == 0` is the
+# guard instead - such a target group serves no load balancer, so deleting it
+# cannot break live traffic. Residual risk is the few seconds between an
+# in-cluster controller creating a target group and attaching it to its load
+# balancer; the controller recreates it on the next reconcile.
 target_group_arns=$(paginate "aws elbv2 describe-target-groups --region $region" "TargetGroups[?length(LoadBalancerArns)==\`0\`].TargetGroupArn" | tr '\t' '\n' | grep -v '^$' || true)
 
 if [ -n "$target_group_arns" ]; then

--- a/.github/workflows/scripts/aws_regional_cleanup.sh
+++ b/.github/workflows/scripts/aws_regional_cleanup.sh
@@ -484,3 +484,71 @@ if [ -n "$target_group_arns" ]; then
             'echo "Deleting orphaned Target Group: $2"; aws elbv2 delete-target-group --region "$1" --target-group-arn "$2" || true' _ "$region" {}
     fi
 fi
+
+echo "Deleting abandoned ECS clusters"
+# cloud-nuke cannot remove these. An ECS cluster exposes no creation timestamp,
+# and cloud-nuke excludes every resource without one as soon as a time filter is
+# set. Confirmed against v0.52.0, which logs for each cluster:
+#   DEBUG  Resource has no creation time but a time filter is set - excluding for safety
+# The filter is always set, even when --older-than is omitted, so the ecs-cluster
+# resource type is inert for this account and clusters pile up indefinitely.
+#
+# Age is reconstructed from a first-seen tag, the only way to date a resource the
+# API refuses to timestamp. cloud-nuke already writes `cloud-nuke-first-seen` on
+# every cluster it scans, and leaves the value untouched on later runs, so it is
+# reused here: the clock then starts at the first nightly sweep that ever saw the
+# cluster rather than at the first sweep running this code. Our own tag is written
+# only as a fallback, so this keeps working if cloud-nuke ever stops tagging.
+#
+# Two guards keep it safe:
+#   - a cluster is only ever a candidate while completely idle, so one sitting
+#     between two deployments is never at risk;
+#   - it must then stay idle for the whole cleanup window before anything happens.
+ECS_CLOUD_NUKE_TAG="cloud-nuke-first-seen"
+ECS_FALLBACK_TAG="infraex-cleanup-first-seen"
+
+ecs_cluster_arns=$(paginate "aws ecs list-clusters --region $region" "clusterArns[]" | tr '\t' '\n' | sed '/^$/d')
+
+if [ -n "$ecs_cluster_arns" ]; then
+    while IFS= read -r cluster_arn
+    do
+        if [ -z "$cluster_arn" ]; then
+            continue
+        fi
+        cluster_name="${cluster_arn##*/}"
+
+        # A cluster still holding instances, tasks or services is in use, whatever
+        # its age. Counts are read in one call and summed.
+        in_use=$(aws ecs describe-clusters --region "$region" --clusters "$cluster_arn" \
+            --query 'clusters[0].[registeredContainerInstancesCount,runningTasksCount,pendingTasksCount,activeServicesCount]' \
+            --output text 2>/dev/null | tr '\t' '\n' | awk '{ total += $1 } END { print total + 0 }')
+        if [ "${in_use:-1}" -ne 0 ]; then
+            echo "Skipping ECS cluster: $cluster_name (still in use)"
+            continue
+        fi
+
+        cluster_tags=$(aws ecs list-tags-for-resource --region "$region" --resource-arn "$cluster_arn" --output json 2>/dev/null || echo '{}')
+        first_seen=$(echo "$cluster_tags" | jq -r --arg primary "$ECS_CLOUD_NUKE_TAG" --arg fallback "$ECS_FALLBACK_TAG" \
+            '(.tags // []) | (map(select(.key == $primary)) + map(select(.key == $fallback)))[0].value // ""' 2>/dev/null || true)
+
+        if [ -z "$first_seen" ] || [ "$first_seen" = "null" ]; then
+            # First idle sighting and cloud-nuke has not tagged it yet, which is
+            # expected since it runs after this script. Record the date and leave
+            # the cluster alone. Tagging is best-effort: an untaggable cluster is
+            # simply reconsidered next run rather than aborting the sweep.
+            echo "Recording first idle sighting of ECS cluster: $cluster_name"
+            execute_or_simulate "aws ecs tag-resource --region $region --resource-arn $cluster_arn --tags key=$ECS_FALLBACK_TAG,value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" || true
+            continue
+        fi
+
+        if ! is_old_enough "$(iso_to_epoch "$first_seen")"; then
+            echo "Skipping ECS cluster: $cluster_name (idle since $first_seen, too recent)"
+            continue
+        fi
+
+        echo "Deleting ECS cluster: $cluster_name (idle since $first_seen)"
+        # Best-effort: a cluster still referenced by a capacity provider or a
+        # draining instance cannot be deleted and must not abort the sweep.
+        execute_or_simulate "aws ecs delete-cluster --region $region --cluster $cluster_arn" || true
+    done <<< "$ecs_cluster_arns"
+fi

--- a/.github/workflows/scripts/aws_route53_cleanup.sh
+++ b/.github/workflows/scripts/aws_route53_cleanup.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Deletes Route53 records left behind by external-dns when a cluster teardown fails.
+#
+# external-dns creates one alias record per Kubernetes Service/Ingress plus a TXT
+# ownership record in the registry. When a CI run fails before its teardown step,
+# external-dns never removes them, and cloud-nuke deletes the load balancer they
+# point at minutes later. Nothing else cleans them up, so they accumulate at every
+# failed run: the camunda.ie zone had reached 4024 records before this script was
+# introduced, i.e. 40% of the hard limit of 10 000 records per hosted zone. Once
+# that limit is hit external-dns stops being able to publish anything and every
+# ingress-dependent test breaks at once.
+#
+# A record still pointing at a released AWS endpoint is also a subdomain takeover
+# candidate, which is the reason this runs daily rather than weekly.
+#
+# Three classes of leftover are collected, each self-validating so that no naming
+# convention is relied upon and a live environment can never be affected:
+#
+#   1. alias records whose load balancer no longer exists in this region, plus the
+#      external-dns TXT registry entries that track them;
+#   2. CNAMEs pointing at an OpenSearch endpoint in this region whose domain is
+#      gone, which Terraform publishes and never removes on a failed destroy;
+#   3. cert-manager DNS01 challenges and ACM validation CNAMEs whose validated
+#      name has disappeared from the zone.
+#
+# A record whose target is still alive cannot match any of them.
+#
+# Convergence: this script runs before cloud-nuke in the nightly workflow, so the
+# load balancers of the run being torn down are still alive when it executes and
+# their records are kept. cloud-nuke then deletes the load balancers, and the next
+# nightly run removes the records. Orphans therefore drain with a one-day lag,
+# the same way orphaned target groups do in aws_regional_cleanup.sh.
+
+DRY_RUN=${DRY_RUN:-false}
+
+if [ -z "${1:-}" ]; then
+    echo "Please provide the AWS region as the first argument."
+    exit 1
+fi
+
+region="$1"
+
+# Route53 accepts at most 1000 changes per ChangeResourceRecordSets call. 200 keeps
+# each request well under the accompanying limit on the total size of the batch.
+BATCH_SIZE=200
+
+echo "Deleting orphaned Route53 records for load balancers removed in $region..."
+
+# DNS names of every regional endpoint still alive, normalised the way Route53
+# stores targets: lowercase, no trailing dot. Load balancers cover the alias
+# records external-dns publishes; OpenSearch covers the CNAMEs Terraform points at
+# a domain's VPC endpoint.
+#
+# Every one of these calls must succeed. This list is what protects live records:
+# if a call fails - expired credentials, throttling, a missing permission - it
+# comes back empty, every record in the zone then looks orphaned, and the sweep
+# below would delete the whole zone. An empty result is only ever legitimate when
+# the API genuinely reports no resources, so a non-zero exit aborts the run.
+#
+# Results are appended to a file rather than piped: an `exit` inside a command
+# substitution only terminates the subshell, so a failure there would go unnoticed
+# and produce exactly the empty list this guards against.
+endpoints_file=$(mktemp)
+cleanup_endpoints_file() { rm -f "$endpoints_file"; }
+trap cleanup_endpoints_file EXIT
+
+collect_endpoints() {
+    local description="$1"
+    shift
+    local output
+    if ! output=$("$@" 2>&1); then
+        echo "Cannot list $description in $region, aborting to avoid deleting live records:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+    printf '%s\n' "$output" >> "$endpoints_file"
+}
+
+collect_endpoints "application and network load balancers" \
+    aws elbv2 describe-load-balancers --region "$region" --query 'LoadBalancers[].DNSName' --output text || exit 1
+collect_endpoints "classic load balancers" \
+    aws elb describe-load-balancers --region "$region" --query 'LoadBalancerDescriptions[].DNSName' --output text || exit 1
+
+if ! opensearch_domains=$(aws opensearch list-domain-names --region "$region" \
+        --query 'DomainNames[].DomainName' --output text 2>&1); then
+    echo "Cannot list OpenSearch domains in $region, aborting:" >&2
+    echo "$opensearch_domains" >&2
+    exit 1
+fi
+for domain in $opensearch_domains; do
+    collect_endpoints "OpenSearch domain $domain" \
+        aws opensearch describe-domain --region "$region" --domain-name "$domain" \
+        --query 'DomainStatus.[Endpoint,Endpoints.vpc]' --output text || exit 1
+done
+
+# "None" is what the CLI prints for a domain that has no VPC endpoint.
+alive_endpoints_json=$(tr '\t' '\n' < "$endpoints_file" \
+    | tr '[:upper:]' '[:lower:]' | sed -e 's/\.$//' -e '/^$/d' -e '/^none$/d' | sort -u \
+    | jq -R -s -c 'split("\n") | map(select(length > 0))')
+echo "Live endpoints in $region: $(echo "$alive_endpoints_json" | jq 'length')"
+
+# Private zones are excluded: they serve internal names for resources cloud-nuke
+# deletes wholesale along with their VPC, and they are not reachable from the
+# internet so they carry no takeover risk.
+# Failing here is treated the same way: a silent empty list would turn this script
+# into a no-op that nobody notices, which is how the leak grew unseen in the first
+# place.
+if ! hosted_zones_raw=$(aws route53 list-hosted-zones \
+        --query "HostedZones[?Config.PrivateZone==\`false\`].Id" --output text 2>&1); then
+    echo "Cannot list hosted zones, aborting:" >&2
+    echo "$hosted_zones_raw" >&2
+    exit 1
+fi
+hosted_zones=$(printf '%s\n' "$hosted_zones_raw" | tr '\t' '\n' | sed -e 's|^/hostedzone/||' -e '/^$/d')
+
+for zone_id in $hosted_zones; do
+    zone_name=$(aws route53 get-hosted-zone --id "$zone_id" --query 'HostedZone.Name' --output text 2>/dev/null || echo "$zone_id")
+
+    records_file=$(mktemp)
+    changes_file=$(mktemp)
+
+    if ! aws route53 list-resource-record-sets --hosted-zone-id "$zone_id" --output json > "$records_file" 2>/dev/null; then
+        echo "Skipping zone $zone_name (cannot list records)"
+        rm -f "$records_file" "$changes_file"
+        continue
+    fi
+
+    # SOA and NS records carry no AliasTarget and can therefore never be selected
+    # here, which keeps the zone delegation intact by construction.
+    jq --argjson alive "$alive_endpoints_json" --arg region "$region" '
+        # Regional AWS endpoints this script is able to validate. A record is only
+        # ever a candidate if its target matches one of these, so records pointing
+        # at anything else (the zone apex S3 website, a delegation, a third party)
+        # are out of scope by construction, as are SOA and NS which carry neither
+        # an AliasTarget nor a CNAME value.
+        def in_region_endpoint:
+              test("elb\\." + $region + "\\.amazonaws\\.com$")          # ALB / NLB
+            or test($region + "\\.elb\\.amazonaws\\.com$")              # classic ELB
+            or test($region + "\\.es\\.amazonaws\\.com$");              # OpenSearch
+
+        def target_of:
+            if .AliasTarget != null then .AliasTarget.DNSName
+            elif .Type == "CNAME" then (.ResourceRecords // [])[0].Value
+            else null end
+            | if . == null then null else (ascii_downcase | rtrimstr(".")) end;
+
+        [ .ResourceRecordSets[]
+          | select(target_of != null)
+          # The target is bound to a variable first: inside `index(...)` the input
+          # is the $alive array, so referring to the record there would resolve
+          # against the array instead.
+          | select(target_of | in_region_endpoint)
+          | select(target_of as $target | ($alive | index($target)) | not)
+        ] as $orphans
+        | ($orphans | map(.Name) | unique) as $orphan_names
+        # The external-dns TXT registry either reuses the record name as-is or
+        # prefixes the record type to it. Only records carrying the external-dns
+        # heritage marker are touched, so unrelated TXT records are left alone.
+        | [ .ResourceRecordSets[]
+            | select(.Type == "TXT")
+            | select((.ResourceRecords // []) | map(.Value) | join(" ") | test("heritage=external-dns"))
+            | . as $txt
+            | select($orphan_names | any(. as $name
+                | $txt.Name == $name
+                or $txt.Name == ("a-" + $name)
+                or $txt.Name == ("aaaa-" + $name)
+                or $txt.Name == ("cname-" + $name)))
+          ] as $registry
+        # Names that will still exist in the zone once the records above are gone.
+        | ([ .ResourceRecordSets[].Name ] - ($orphans + $registry | map(.Name)) | unique) as $surviving_names
+        # Domain validation records: cert-manager DNS01 challenges and the CNAMEs
+        # ACM asks for. Both only make sense while the name they validate exists;
+        # once that name is gone they are dead weight and, unlike everything above,
+        # nothing else will ever remove them.
+        # Matched by their exact purpose rather than by a generic "label starts
+        # with an underscore" rule, which would also catch _dmarc, _domainkey and
+        # SRV records that are legitimately unaccompanied by an A record.
+        # Race: a challenge published seconds before external-dns creates the
+        # record it validates would be collected here. The window is minutes
+        # against a daily schedule, and both issuers republish the record on their
+        # next reconcile, so the failure mode is a retry, not a lost certificate.
+        | [ .ResourceRecordSets[]
+            | select((.Type == "TXT" and (.Name | startswith("_acme-challenge.")))
+                     or (.Type == "CNAME"
+                         and ((.ResourceRecords // [])[0].Value // ""
+                              | ascii_downcase | rtrimstr(".") | endswith(".acm-validations.aws"))))
+            | select((.Name | sub("^_[^.]+\\."; "")) as $validated
+                     | ($surviving_names | index($validated)) | not)
+          ] as $validations
+        | ($orphans + $registry + $validations) | map({Action: "DELETE", ResourceRecordSet: .})' \
+        "$records_file" > "$changes_file"
+
+    total=$(jq 'length' "$changes_file")
+    if [ "$total" -eq 0 ]; then
+        echo "Zone $zone_name: nothing to delete"
+        rm -f "$records_file" "$changes_file"
+        continue
+    fi
+
+    echo "Zone $zone_name: $total orphaned record(s) to delete"
+
+    if [ "$DRY_RUN" = true ]; then
+        jq -r '.[] | "[DRY RUN] Would delete \(.ResourceRecordSet.Type) \(.ResourceRecordSet.Name)"' "$changes_file"
+        rm -f "$records_file" "$changes_file"
+        continue
+    fi
+
+    offset=0
+    while [ "$offset" -lt "$total" ]; do
+        batch_file=$(mktemp)
+        jq -c --argjson offset "$offset" --argjson size "$BATCH_SIZE" \
+            '{Changes: .[$offset:$offset + $size]}' "$changes_file" > "$batch_file"
+
+        # Best-effort per batch: a record removed by a concurrent external-dns
+        # reconcile makes only its own batch fail, and the next run picks up
+        # whatever is left rather than aborting the whole sweep under set -e.
+        if aws route53 change-resource-record-sets --hosted-zone-id "$zone_id" \
+             --change-batch "file://$batch_file" --query 'ChangeInfo.Id' --output text >/dev/null 2>&1; then
+            echo "  deleted $(jq '.Changes | length' "$batch_file") record(s)"
+        else
+            echo "  batch starting at offset $offset failed, continuing"
+        fi
+        rm -f "$batch_file"
+
+        offset=$((offset + BATCH_SIZE))
+        # Route53 throttles mutating calls at 5 requests per second per account.
+        sleep 1
+    done
+
+    rm -f "$records_file" "$changes_file"
+done


### PR DESCRIPTION
Three fixes to the nightly AWS cleanup, found while running it manually against `eu-west-2`/`eu-west-3`.

## 1. The regional sweep ignored the cleanup window

`aws_regional_cleanup.sh` never read `CLEANUP_OLDER_THAN`. cloud-nuke runs later in the same job and deliberately keeps resources younger than that window, so the sweep was deleting the dependencies of clusters cloud-nuke was about to spare. The cluster stayed up and lost IRSA silently — no error anywhere.

A dry run on a weekday evening targeted **all 7 OIDC providers of ACTIVE EKS clusters created in the previous hours**, plus their control-plane log groups, an active cross-region VPC peering and a Client VPN endpoint.

Two independent guards, so a running cluster is protected even in the weekly regions where the window is `0h`:

- honour `CLEANUP_OLDER_THAN` wherever AWS exposes a creation timestamp (OIDC providers, Client VPN, ACM certificates, Cognito user pools, log groups). An unreadable timestamp keeps the resource — a missed deletion is picked up the next night, a wrong one is not recoverable.
- never touch a resource owned by an EKS cluster that still exists.

Timestamps go through `python3` rather than `date(1)`: GNU and BSD disagree on parsing *and* epoch formatting, and this runs on CI and on laptops. Naive timestamps are pinned to UTC instead of the runner timezone.

Elastic IPs and target groups keep no age filter — neither exposes a creation time. Documented in place.

**Ordering was checked and deliberately left alone.** The sweep runs before cloud-nuke because it removes the Client VPN endpoints and VPC peerings that block VPC deletion later.

## 2. Route53 records leaked on every failed teardown

external-dns publishes an alias record plus a TXT registry entry per Service/Ingress. On a failed teardown nothing removes them, and cloud-nuke deletes the load balancer they point at minutes later.

The `camunda.ie` zone had reached **4024 records, 40% of the 10 000-per-zone limit**. At that ceiling external-dns can no longer publish anything and every ingress-dependent test fails at once. A record still pointing at a released AWS endpoint is also a subdomain takeover candidate — hence daily rather than weekly.

New `aws_route53_cleanup.sh` collects three classes, each self-validating so no naming convention is relied upon:

| Class | Orphaned when |
|---|---|
| alias records + their external-dns TXT registry entries | the load balancer is gone from this region |
| CNAMEs to an OpenSearch endpoint | the domain is gone |
| cert-manager DNS01 challenges, ACM validation CNAMEs | the validated name has left the zone |

Validated against a snapshot of the 4024 real records: the union across regions selects **exactly the 4020 that were orphaned**, and never SOA, NS or the apex — none of which carry an alias target, so they cannot match by construction.

Enumerating live endpoints **aborts the run on any API error**. That list is the only thing protecting live records; an expired token returning an empty list would mark every record orphaned and wipe the zone. Results accumulate in a file rather than a pipeline, because an `exit` inside a command substitution only leaves the subshell.

Convergence is one day: the step runs before cloud-nuke, so tonight's load balancers are still alive and their records survive; cloud-nuke removes them and tomorrow's run clears the records. Same pattern as orphaned target groups.

## 3. Stale S3 allowlist

`infraex-terraform-state` and `infraex-artifacts` are absent from the canonical keeplist `aws_global_cleanup.sh` reads, so the weekly cleanup would delete them and the audit reported them missing every week. Neither exists in the account. Dropped, with a pointer to the source of truth.

## Testing

- `shellcheck` and `pre-commit` (incl. `actionlint`) clean
- both scripts exercised live against all five CI/weekly regions
- failure path verified: a broken profile aborts with exit 1 instead of silently deleting
- selection logic replayed against the 4024-record snapshot, per region

Two bugs were caught this way and are fixed here: `grep -v` on empty input aborting the script under `pipefail`, and a jq expression resolving `.AliasTarget` against the wrong input. Both were invisible on the happy path.

## Note for reviewers

Nothing here changes the region matrix. `eu-central-2` and `eu-south-1` from #534 are untouched — but they were **not** part of the manual cleanup run, so they may still hold leftovers.

## 4. cloud-nuke never deletes ECS clusters

Found while sweeping all 19 enabled regions: four empty ECS clusters had survived every nightly run, across three regions.

The cause is not a permission or a tag. `cloud-nuke` v0.52.0 logs, for each cluster:

```
DEBUG  Resource has no creation time but a time filter is set - excluding for safety
```

The ECS API exposes no creation timestamp for a cluster, and cloud-nuke excludes any untimestamped resource as soon as a time filter is set. The filter is always set — verified that omitting `--older-than` entirely still yields `Found total of 0 resources`. The `ecs-cluster` resource type is therefore inert for this account and clusters accumulate indefinitely.

cloud-nuke *does* write a `cloud-nuke-first-seen` tag while scanning, and leaves the value untouched across runs, but never reads it back to satisfy its own filter. Verified by re-running with the tag present: same exclusion, still 0 resources.

That tag is reused here as the age signal, so the clock starts at the first nightly sweep that ever saw the cluster rather than at the first sweep running this code. Our own tag is written only when cloud-nuke has not tagged yet — expected, since cloud-nuke runs after this script — which also keeps the sweep working if cloud-nuke stops tagging.

Two guards, so an environment in use is never affected:

- a cluster is a candidate only while completely idle: no registered instances, no running or pending tasks, no active services
- it must then stay idle for the whole cleanup window

Tested against the real clusters, all three branches:

| Situation | Result |
|---|---|
| tag from 14:01Z, window 12h | `Skipping ... too recent` |
| tag from 14:01Z, window 0h | `Deleting ...` |
| no tag at all | `Recording first idle sighting` |

Also verified that a backdated tag flips the decision, and that ECS tagging works on the one cluster carrying no tags at all.

### Side note

cloud-nuke mutates during `--dry-run`: it writes `cloud-nuke-first-seen` in the scan phase, before the nuke phase is skipped. Worth knowing before treating its dry-run as read-only.
