### PR TITLE
security(lint-global): least-privilege autofix token and read-only GITHUB_TOKEN

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -11,6 +11,12 @@ on:
                 default: renovate[bot]
                 type: string
 
+# The auto-fix commit is pushed with a dedicated, repository-scoped GitHub App token,
+# never with GITHUB_TOKEN. GITHUB_TOKEN therefore stays read-only for the whole run,
+# including the pre-commit steps which install and execute third-party hook code.
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: pre-commit
@@ -20,8 +26,17 @@ jobs:
             # This step is required as we want to use the bot for the checkout,
             # this way, the auto-fix step will commit using this user
             - name: Set autofix_pr environment variable
+              env:
+                  ACTOR: ${{ github.actor }}
+                  AUTOFIX_ACTOR: ${{ inputs.autofix-actor }}
+                  EVENT_NAME: ${{ github.event_name }}
+                  HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+                  BASE_REPO: ${{ github.repository }}
               run: |
-                  if [[ "${{ github.actor }}" == "${{ inputs.autofix-actor }}" && "${{ github.event_name }}" == "pull_request" ]]; then
+                  # Auto-fix needs a privileged App token, so it is restricted to the designated
+                  # bot actor AND to same-repository pull requests. A fork head is never checked
+                  # out while that token is available to the job.
+                  if [[ "${ACTOR}" == "${AUTOFIX_ACTOR}" && "${EVENT_NAME}" == "pull_request" && "${HEAD_REPO}" == "${BASE_REPO}" ]]; then
                     echo "autofix_pr=true" | tee -a "$GITHUB_ENV"
                   else
                     echo "autofix_pr=false" | tee -a "$GITHUB_ENV"
@@ -36,6 +51,10 @@ jobs:
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common
                   github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
                   github-app-private-key-vault-path: secret/data/products/infrastructure-experience/ci/common
+                  # Scope the installation token to the repository under test. Without an explicit
+                  # `repositories`, a token requested for an owner is valid for every repository of
+                  # the installation, with every permission the App holds.
+                  repositories: ${{ github.event.repository.name }}
                   vault-auth-method: approle
                   vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
                   vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
@@ -46,11 +65,19 @@ jobs:
               # see http>s://github.com/EndBug/add-and-commit?tab=readme-ov-file#working-with-prs
               with:
                   token: ${{ steps.generate-github-token.outputs.token }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
+                  # Same-repository PRs only, enforced by the autofix_pr guard above.
+                  repository: ${{ github.repository }}
                   ref: ${{ github.event.pull_request.head.ref }}
+                  # The auto-fix commit is created through the GitHub API by
+                  # getsentry/action-github-commit, so no git credential is needed after checkout.
+                  # Leaving it persisted would expose the App token on the runner while pre-commit
+                  # executes third-party hook code.
+                  persist-credentials: false
 
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
               if: env.autofix_pr == 'false'
+              with:
+                  persist-credentials: false
 
             # TODO: Renable when switching back to upstream actionlint
             # - name: Centralized Actionlint
@@ -64,7 +91,7 @@ jobs:
 
             # Setup tool cache
             - name: Install asdf tools
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
 
             - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
               id: pre_commit_check_first_run
@@ -85,7 +112,7 @@ jobs:
               # We want to apply automatic fixes made by pre-commit.
               if: always() && env.autofix_pr == 'true'  && steps.pre_commit_check_first_run.outcome != 'success' && steps.pre_commit_check_second_run.outcome
                   == 'success'
-              uses: getsentry/action-github-commit@5972d5f578ad77306063449e718c0c2a6fbc4ae1 # main
+              uses: getsentry/action-github-commit@5972d5f578ad77306063449e718c0c2a6fbc4ae1 # v2.1.0
               with:
                   github-token: ${{ steps.generate-github-token.outputs.token }}
                   message: 'chore: update files from pre-commit run'


### PR DESCRIPTION
## Context

`lint-global.yml` runs `pre-commit run --all-files` — which installs and executes
third-party hook environments on the runner — and, on the autofix path, checks out a
PR head and commits back with a GitHub App token. That combination gives untrusted
code a job context holding a privileged credential. This PR reduces what that
credential can reach and how long it stays available.

Hardening only. No change to when autofix triggers for the designated bot on
same-repository PRs.

## Changes

**1. `permissions: contents: read` at workflow level**

The workflow had no `permissions:` block, so `GITHUB_TOKEN` inherited the caller's
defaults — write in most of our repos — and stayed writable for the whole run,
including the two `pre-commit` steps. The autofix commit never used `GITHUB_TOKEN`
(it uses the App token), so dropping to read costs nothing.

Reusable-workflow semantics: a `permissions` block declared here applies to the job
and can only be equal to or more restrictive than the caller's. Callers do not need
to change anything.

**2. App installation token scoped to the repository under test**

The token step passed no `repositories:`. Left implicit, an installation token can be
issued for the whole installation — every repository, every permission the App holds
— rather than the one repo being linted. Now explicit:

```yaml
repositories: ${{ github.event.repository.name }}
```

zizmor [`github-app`](https://docs.zizmor.sh/audits/#github-app). The token step only
runs on `pull_request`, so `github.event.repository` is always populated there.

**3. `persist-credentials: false` on both checkouts**

zizmor [`artipacked`](https://docs.zizmor.sh/audits/#artipacked). Neither checkout set
it, so it defaulted to `true` and the token was written to disk on the runner before
`pre-commit` ran third-party hook code.

Nothing needs it after checkout: `getsentry/action-github-commit` creates the commit
through the GitHub API using its `github-token` input (it only shells out to `git` to
*read* the working tree, and takes the branch from `GITHUB_HEAD_REF`). There is no
`git push` in that action.

**4. Autofix gated on same-repository PRs**

Previously the autofix checkout targeted `github.event.pull_request.head.repo.full_name`
— attacker-influenced event data — while the App token was live. Now the guard also
requires head repo == base repo, and the checkout targets `github.repository`. A fork
head is never checked out in a job holding the token.

In practice the designated actor (`renovate[bot]`) never opens fork PRs, so this is
not a behaviour change; it removes the possibility rather than relying on it.

**5. Smaller items**

- Actor/event comparison moved from `run:` interpolation into `env:` and quoted shell
  variables — zizmor [`template-injection`](https://docs.zizmor.sh/audits/#template-injection).
- `getsentry/action-github-commit` comment retagged `# main` → `# v2.1.0`. The pinned
  SHA is unchanged and is exactly `v2.1.0`; this only stops Renovate from tracking a
  mutable branch tip.
- Dropped the no-op `/./` in the `asdf-install-tooling` ref — zizmor
  [`obfuscation`](https://docs.zizmor.sh/audits/#obfuscation), cosmetic.

## Verification

- `zizmor --persona=auditor .github/workflows/lint-global.yml` → **no findings**
  (was 8: 2 high, 4 medium, 2 low).
- `pre-commit run --files .github/workflows/lint-global.yml` → all hooks pass,
  including `actionlint`.
- Every `uses:` in this file is pinned by commit SHA.

## Follow-ups (not in this PR)

- **Callers pin this workflow by SHA, so merging this does not fix them.** Each of the
  6 consumer repos needs its own bump once a tag is cut. One of them is several minor
  versions behind and needs a larger jump.
- `camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets` is
  still pinned to a `main` commit rather than a release tag. It is SHA-pinned, so it is
  immutable; the current pin is newer than the latest per-action tag, so switching would
  be a downgrade. Left alone deliberately.
- `zizmor` across the rest of `.github/` reports 227 findings. Out of scope here; worth
  its own PR, and worth adding as a pre-commit hook afterwards.
