### PR TITLE
security(lint-global): run pre-commit hooks without the autofix token [ready]

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -146,24 +146,6 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            # Fresh runner: no pre-commit hook code has executed here, so there is no planted git
-            # hook, PATH shim or BASH_ENV able to intercept the token minted below.
-            - name: Generate token for GitHub
-              id: generate-github-token
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@472b20a51fb5c7c9ff991ed6177769eab487eb34 # main
-              with:
-                  github-app-id-vault-key: GITHUB_APP_ID
-                  github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common
-                  github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
-                  github-app-private-key-vault-path: secret/data/products/infrastructure-experience/ci/common
-                  # Pin the installation token to the repository under test rather than relying on
-                  # the composite action's default.
-                  repositories: ${{ github.event.repository.name }}
-                  vault-auth-method: approle
-                  vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
-                  vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-                  vault-url: ${{ secrets.VAULT_ADDR }}
-
             # Same-repository PRs only, enforced by the autofix_pr guard in the lint job, so the
             # default `repository` is the PR head repository.
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -179,8 +161,10 @@ jobs:
                   name: pre-commit-autofix-patch
 
             - name: Check patch size
-              # Authoritative: no pre-commit hook code has run in this job, so `git` and the
-              # patch file are both trustworthy here.
+              # The patch content is untrusted: it was produced by repository-supplied hook code
+              # in the `lint` job. What is trustworthy here is the toolchain measuring it —
+              # no hook code has run on this runner, so `git`, `wc` and `awk` cannot have been
+              # shimmed to under-report.
               #
               # This bounds blast radius, it is not an injection defence: a hostile hook would
               # plant a handful of lines, well under any usable threshold. What it does catch
@@ -217,6 +201,26 @@ jobs:
                     exit 1
                   fi
                   rm -f autofix.patch
+
+            # Minted last, deliberately: the token only needs to exist for the commit call, so
+            # it is not alive while the untrusted patch is measured and applied. No pre-commit
+            # hook code has executed on this runner either, so there is no planted git hook,
+            # PATH shim or BASH_ENV able to intercept it.
+            - name: Generate token for GitHub
+              id: generate-github-token
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@472b20a51fb5c7c9ff991ed6177769eab487eb34 # main
+              with:
+                  github-app-id-vault-key: GITHUB_APP_ID
+                  github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common
+                  github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
+                  github-app-private-key-vault-path: secret/data/products/infrastructure-experience/ci/common
+                  # Pin the installation token to the repository under test rather than relying on
+                  # the composite action's default.
+                  repositories: ${{ github.event.repository.name }}
+                  vault-auth-method: approle
+                  vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+                  vault-url: ${{ secrets.VAULT_ADDR }}
 
             - name: Commit Changes made by pre-commit fix
               uses: getsentry/action-github-commit@5972d5f578ad77306063449e718c0c2a6fbc4ae1 # v2.1.0

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -23,6 +23,15 @@ on:
                     bulk content (binaries, generated blobs) that a line count does not.
                 default: 65536
                 type: number
+            autofix-artifact-name:
+                description: |
+                    Name of the artifact carrying the patch between the two jobs. Artifact names
+                    are unique per workflow *run*, not per job, so override this if a caller
+                    invokes this workflow more than once in the same run — through a matrix, or
+                    two separate calls. Leaving both instances on the same name makes the second
+                    upload fail and lets each one download the other's patch.
+                default: pre-commit-autofix-patch
+                type: string
 
 # The auto-fix commit is created with a dedicated GitHub App token in a separate job,
 # never with GITHUB_TOKEN. GITHUB_TOKEN therefore stays read-only for the whole run,
@@ -133,8 +142,11 @@ jobs:
               if: steps.patch.outputs.has_fixes == 'true'
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
-                  name: pre-commit-autofix-patch
+                  name: ${{ inputs.autofix-artifact-name }}
                   path: autofix.patch
+                  # The patch is derived from pull request content, so it is no more sensitive
+                  # than the PR itself. Kept briefly so a human can download exactly what the
+                  # bot committed.
                   retention-days: 1
 
     autofix-apply:
@@ -158,7 +170,7 @@ jobs:
             - name: Download auto-fix patch
               uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
               with:
-                  name: pre-commit-autofix-patch
+                  name: ${{ inputs.autofix-artifact-name }}
 
             - name: Check patch size
               # The patch content is untrusted: it was produced by repository-supplied hook code

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -11,46 +11,54 @@ on:
                 default: renovate[bot]
                 type: string
 
+# The auto-fix commit is created with a dedicated GitHub App token in a separate job,
+# never with GITHUB_TOKEN. GITHUB_TOKEN therefore stays read-only for the whole run,
+# including the pre-commit steps which install and execute third-party hook code.
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: pre-commit
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        # Repository-supplied pre-commit hooks execute in this job. It therefore holds no
+        # credential and references no secret: it only produces a patch as an artifact.
+        outputs:
+            autofix_pr: ${{ steps.mode.outputs.autofix_pr }}
+            has_fixes: ${{ steps.patch.outputs.has_fixes }}
         steps:
-            # This step is required as we want to use the bot for the checkout,
-            # this way, the auto-fix step will commit using this user
-            - name: Set autofix_pr environment variable
+            - name: Determine whether this run may auto-fix
+              id: mode
+              env:
+                  ACTOR: ${{ github.actor }}
+                  AUTOFIX_ACTOR: ${{ inputs.autofix-actor }}
+                  EVENT_NAME: ${{ github.event_name }}
+                  HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+                  BASE_REPO: ${{ github.repository }}
               run: |
-                  if [[ "${{ github.actor }}" == "${{ inputs.autofix-actor }}" && "${{ github.event_name }}" == "pull_request" ]]; then
-                    echo "autofix_pr=true" | tee -a "$GITHUB_ENV"
+                  # Auto-fix needs a privileged App token, so it is restricted to the designated
+                  # bot actor AND to same-repository pull requests. A fork head is never checked
+                  # out in the job that holds that token.
+                  if [[ "${ACTOR}" == "${AUTOFIX_ACTOR}" && "${EVENT_NAME}" == "pull_request" && "${HEAD_REPO}" == "${BASE_REPO}" ]]; then
+                    echo "autofix_pr=true" | tee -a "$GITHUB_OUTPUT"
                   else
-                    echo "autofix_pr=false" | tee -a "$GITHUB_ENV"
+                    echo "autofix_pr=false" | tee -a "$GITHUB_OUTPUT"
                   fi
 
-            - name: Generate token for GitHub
-              id: generate-github-token
-              if: env.autofix_pr == 'true'
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@472b20a51fb5c7c9ff991ed6177769eab487eb34 # main
-              with:
-                  github-app-id-vault-key: GITHUB_APP_ID
-                  github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common
-                  github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
-                  github-app-private-key-vault-path: secret/data/products/infrastructure-experience/ci/common
-                  vault-auth-method: approle
-                  vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
-                  vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-                  vault-url: ${{ secrets.VAULT_ADDR }}
-
+            # On the auto-fix path we lint the PR head itself, because the resulting patch is
+            # committed back onto that branch. Elsewhere the default checkout (merge result on
+            # pull_request) is kept.
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-              if: env.autofix_pr == 'true'
-              # see http>s://github.com/EndBug/add-and-commit?tab=readme-ov-file#working-with-prs
+              if: steps.mode.outputs.autofix_pr == 'true'
               with:
-                  token: ${{ steps.generate-github-token.outputs.token }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
                   ref: ${{ github.event.pull_request.head.ref }}
+                  persist-credentials: false
 
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-              if: env.autofix_pr == 'false'
+              if: steps.mode.outputs.autofix_pr == 'false'
+              with:
+                  persist-credentials: false
 
             # TODO: Renable when switching back to upstream actionlint
             # - name: Centralized Actionlint
@@ -64,7 +72,7 @@ jobs:
 
             # Setup tool cache
             - name: Install asdf tools
-              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              uses: camunda/infraex-common-config/.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
 
             - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
               id: pre_commit_check_first_run
@@ -73,19 +81,92 @@ jobs:
 
             - name: Rerun pre-commit to autofix files if pre-commit failed
               uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-              if: always() && env.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success'
+              if: always() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success'
               id: pre_commit_check_second_run
               with:
                   extra_args: --all-files --verbose
 
-            - name: Commit Changes made by pre-commit fix
-              # This workflow checks the files after the first pre-commit run.
-              # If the second run fixes the files, it indicates that pre-commit applied automatic fixes.
-              # If the issue persists, it means pre-commit was unable to resolve it.
-              # We want to apply automatic fixes made by pre-commit.
-              if: always() && env.autofix_pr == 'true'  && steps.pre_commit_check_first_run.outcome != 'success' && steps.pre_commit_check_second_run.outcome
+            # The first pre-commit run checks the files. If the second run passes, pre-commit
+            # applied automatic fixes; if it still fails, pre-commit could not resolve the issue
+            # and there is nothing to commit.
+            - name: Produce auto-fix patch
+              id: patch
+              if: always() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success' && steps.pre_commit_check_second_run.outcome
                   == 'success'
-              uses: getsentry/action-github-commit@5972d5f578ad77306063449e718c0c2a6fbc4ae1 # main
+              run: |
+                  set -euo pipefail
+                  git add --all
+                  git diff --cached --binary > autofix.patch
+                  if [ ! -s autofix.patch ]; then
+                    echo "has_fixes=false" | tee -a "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                  echo "has_fixes=true" | tee -a "$GITHUB_OUTPUT"
+                  git diff --cached --stat
+
+            - name: Upload auto-fix patch
+              if: steps.patch.outputs.has_fixes == 'true'
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              with:
+                  name: pre-commit-autofix-patch
+                  path: autofix.patch
+                  retention-days: 1
+
+    autofix-apply:
+        name: Commit pre-commit fixes
+        needs: lint
+        # `lint` reports failure whenever pre-commit had something to fix, so this job must not
+        # depend on its conclusion — only on the outputs it published.
+        if: ${{ !cancelled() && needs.lint.outputs.autofix_pr == 'true' && needs.lint.outputs.has_fixes == 'true' }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            # Fresh runner: no pre-commit hook code has executed here, so there is no planted git
+            # hook, PATH shim or BASH_ENV able to intercept the token minted below.
+            - name: Generate token for GitHub
+              id: generate-github-token
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@472b20a51fb5c7c9ff991ed6177769eab487eb34 # main
+              with:
+                  github-app-id-vault-key: GITHUB_APP_ID
+                  github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common
+                  github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
+                  github-app-private-key-vault-path: secret/data/products/infrastructure-experience/ci/common
+                  # Pin the installation token to the repository under test rather than relying on
+                  # the composite action's default.
+                  repositories: ${{ github.event.repository.name }}
+                  vault-auth-method: approle
+                  vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+                  vault-url: ${{ secrets.VAULT_ADDR }}
+
+            # Same-repository PRs only, enforced by the autofix_pr guard in the lint job, so the
+            # default `repository` is the PR head repository.
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  # The commit is created through the GitHub API by getsentry/action-github-commit,
+                  # so no git credential is needed after checkout.
+                  persist-credentials: false
+
+            - name: Download auto-fix patch
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+              with:
+                  name: pre-commit-autofix-patch
+
+            - name: Apply auto-fix patch
+              run: |
+                  set -euo pipefail
+                  git apply --stat autofix.patch
+                  # Leave the changes unstaged: action-github-commit collects them with
+                  # `git ls-files -om`, which compares the working tree against the index.
+                  if ! git apply autofix.patch; then
+                    echo "::error::Could not apply the pre-commit patch, most likely because the branch moved between jobs. Re-run the workflow."
+                    exit 1
+                  fi
+                  rm -f autofix.patch
+
+            - name: Commit Changes made by pre-commit fix
+              uses: getsentry/action-github-commit@5972d5f578ad77306063449e718c0c2a6fbc4ae1 # v2.1.0
               with:
                   github-token: ${{ steps.generate-github-token.outputs.token }}
                   message: 'chore: update files from pre-commit run'

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -178,7 +178,7 @@ jobs:
                   # artifact of the run into per-name subdirectories.
                   name: ${{ needs.lint.outputs.artifact_name }}
 
-            - name: Check patch size
+            - name: Check the patch is safe to auto-commit
               # The patch content is untrusted: it was produced by repository-supplied hook code
               # in the `lint` job. What is trustworthy here is the toolchain measuring it —
               # no hook code has run on this runner, so `git`, `wc` and `awk` cannot have been
@@ -209,6 +209,23 @@ jobs:
                   if [ "$lines" -gt "$MAX_LINES" ] || [ "$bytes" -gt "$MAX_BYTES" ]; then
                     echo "::error::pre-commit patch is too large to auto-commit (${lines} lines / ${bytes} bytes, limits ${MAX_LINES} / ${MAX_BYTES})."
                     echo "::error::Run 'pre-commit run --all-files' locally and commit the result yourself, or raise autofix-max-changed-lines / autofix-max-patch-bytes on the caller."
+                    exit 1
+                  fi
+
+                  # getsentry/action-github-commit sends every file to the API as
+                  # Buffer.from(content).toString(), i.e. decoded as UTF-8, and hardcodes mode
+                  # 100644. Binary content comes out mangled and permissions are lost. The patch
+                  # itself carries both faithfully, so nothing upstream of here notices; refuse
+                  # instead of producing a commit that is quietly wrong.
+                  if printf '%s\n' "$numstat" | awk '$1 == "-" && $2 == "-" { found = 1 } END { exit !found }'; then
+                    echo "::error::The patch changes binary files, which the commit step would corrupt."
+                    echo "::error::Run 'pre-commit run --all-files' locally and commit the result yourself."
+                    exit 1
+                  fi
+                  if grep -qE '^(old|new) mode ' autofix.patch \
+                     || grep -E '^new file mode ' autofix.patch | grep -qv ' 100644$'; then
+                    echo "::error::The patch changes file modes, which the commit step would flatten to 100644."
+                    echo "::error::Run 'pre-commit run --all-files' locally and commit the result yourself."
                     exit 1
                   fi
 

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -35,8 +35,11 @@ jobs:
         name: pre-commit
         runs-on: ubuntu-latest
         timeout-minutes: 10
-        # Repository-supplied pre-commit hooks execute in this job. It therefore holds no
-        # credential and references no secret: it only produces a patch as an artifact.
+        # Repository-supplied pre-commit hooks execute in this job, so it is handed nothing
+        # worth stealing: no App token, no `secrets.*` reference, and a GITHUB_TOKEN held to
+        # `contents: read` by the workflow-level permissions and never written to disk, since
+        # both checkouts set `persist-credentials: false`. Its only output is a patch, passed
+        # to autofix-apply as an artifact.
         outputs:
             autofix_pr: ${{ steps.mode.outputs.autofix_pr }}
             has_fixes: ${{ steps.patch.outputs.has_fixes }}

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -183,8 +183,12 @@ jobs:
               # This bounds blast radius, it is not an injection defence: a hostile hook would
               # plant a handful of lines, well under any usable threshold. What it does catch
               # is a broken or runaway hook rewriting the tree, and bulk content smuggled in
-              # behind a plausible-looking commit message. The real control remains that the
-              # patch lands on a PR branch that still needs review and approval.
+              # behind a plausible-looking commit message.
+              #
+              # What it is really for is keeping the auto-fix commit small enough that a human
+              # reviewing the pull request can actually read it. Note that review is a weaker
+              # backstop than it sounds: unless the branch requires `require_last_push_approval`
+              # or dismisses stale reviews, an approval given before this commit still stands.
               env:
                   MAX_LINES: ${{ inputs.autofix-max-changed-lines }}
                   MAX_BYTES: ${{ inputs.autofix-max-patch-bytes }}

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -10,6 +10,19 @@ on:
                 description: Name of the actor that will trigger auto-fix
                 default: renovate[bot]
                 type: string
+            autofix-max-changed-lines:
+                description: |
+                    Refuse to auto-commit a pre-commit patch that adds or removes more than this
+                    many lines. Bounds a runaway or broken hook; a human still has to look at
+                    anything bigger.
+                default: 200
+                type: number
+            autofix-max-patch-bytes:
+                description: |
+                    Refuse to auto-commit a pre-commit patch larger than this, in bytes. Catches
+                    bulk content (binaries, generated blobs) that a line count does not.
+                default: 65536
+                type: number
 
 # The auto-fix commit is created with a dedicated GitHub App token in a separate job,
 # never with GITHUB_TOKEN. GITHUB_TOKEN therefore stays read-only for the whole run,
@@ -93,6 +106,8 @@ jobs:
               id: patch
               if: always() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success' && steps.pre_commit_check_second_run.outcome
                   == 'success'
+              env:
+                  MAX_BYTES: ${{ inputs.autofix-max-patch-bytes }}
               run: |
                   set -euo pipefail
                   git add --all
@@ -101,8 +116,18 @@ jobs:
                     echo "has_fixes=false" | tee -a "$GITHUB_OUTPUT"
                     exit 0
                   fi
-                  echo "has_fixes=true" | tee -a "$GITHUB_OUTPUT"
                   git diff --cached --stat
+                  # Resource guard only, NOT a security control: hook code has already run in
+                  # this job, so anything here can be lied to. It exists to avoid uploading a
+                  # multi-gigabyte artifact and minting a token for a patch that autofix-apply
+                  # is going to refuse anyway. The authoritative check runs there.
+                  bytes=$(wc -c < autofix.patch | tr -d ' ')
+                  if [ "$bytes" -gt "$MAX_BYTES" ]; then
+                    echo "::error::pre-commit produced a ${bytes}-byte patch, over the ${MAX_BYTES}-byte limit; not auto-committing it."
+                    echo "::error::Run 'pre-commit run --all-files' locally and commit the result yourself, or raise autofix-max-patch-bytes."
+                    exit 1
+                  fi
+                  echo "has_fixes=true" | tee -a "$GITHUB_OUTPUT"
 
             - name: Upload auto-fix patch
               if: steps.patch.outputs.has_fixes == 'true'
@@ -152,6 +177,34 @@ jobs:
               uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
               with:
                   name: pre-commit-autofix-patch
+
+            - name: Check patch size
+              # Authoritative: no pre-commit hook code has run in this job, so `git` and the
+              # patch file are both trustworthy here.
+              #
+              # This bounds blast radius, it is not an injection defence: a hostile hook would
+              # plant a handful of lines, well under any usable threshold. What it does catch
+              # is a broken or runaway hook rewriting the tree, and bulk content smuggled in
+              # behind a plausible-looking commit message. The real control remains that the
+              # patch lands on a PR branch that still needs review and approval.
+              env:
+                  MAX_LINES: ${{ inputs.autofix-max-changed-lines }}
+                  MAX_BYTES: ${{ inputs.autofix-max-patch-bytes }}
+              run: |
+                  set -euo pipefail
+                  numstat=$(git apply --numstat autofix.patch)
+                  bytes=$(wc -c < autofix.patch | tr -d ' ')
+                  files=$(printf '%s\n' "$numstat" | grep -c . || true)
+                  # Binary hunks report "-" instead of a line count; they are covered by MAX_BYTES.
+                  lines=$(printf '%s\n' "$numstat" \
+                          | awk '{ if ($1 != "-") a += $1; if ($2 != "-") d += $2 } END { print a + d + 0 }')
+                  echo "Patch: ${files} file(s), ${lines} changed line(s), ${bytes} byte(s)."
+                  printf '%s\n' "$numstat"
+                  if [ "$lines" -gt "$MAX_LINES" ] || [ "$bytes" -gt "$MAX_BYTES" ]; then
+                    echo "::error::pre-commit patch is too large to auto-commit (${lines} lines / ${bytes} bytes, limits ${MAX_LINES} / ${MAX_BYTES})."
+                    echo "::error::Run 'pre-commit run --all-files' locally and commit the result yourself, or raise autofix-max-changed-lines / autofix-max-patch-bytes on the caller."
+                    exit 1
+                  fi
 
             - name: Apply auto-fix patch
               run: |

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -23,15 +23,6 @@ on:
                     bulk content (binaries, generated blobs) that a line count does not.
                 default: 65536
                 type: number
-            autofix-artifact-name:
-                description: |
-                    Name of the artifact carrying the patch between the two jobs. Artifact names
-                    are unique per workflow *run*, not per job, so override this if a caller
-                    invokes this workflow more than once in the same run — through a matrix, or
-                    two separate calls. Leaving both instances on the same name makes the second
-                    upload fail and lets each one download the other's patch.
-                default: pre-commit-autofix-patch
-                type: string
 
 # The auto-fix commit is created with a dedicated GitHub App token in a separate job,
 # never with GITHUB_TOKEN. GITHUB_TOKEN therefore stays read-only for the whole run,
@@ -49,6 +40,7 @@ jobs:
         outputs:
             autofix_pr: ${{ steps.mode.outputs.autofix_pr }}
             has_fixes: ${{ steps.patch.outputs.has_fixes }}
+            artifact_name: ${{ steps.mode.outputs.artifact_name }}
         steps:
             - name: Determine whether this run may auto-fix
               id: mode
@@ -67,6 +59,13 @@ jobs:
                   else
                     echo "autofix_pr=false" | tee -a "$GITHUB_OUTPUT"
                   fi
+
+                  # Artifact names are unique per workflow *run*, not per job, and this workflow
+                  # is reusable: a caller can invoke it twice in one run, or through a matrix.
+                  # A fixed name would make the second upload fail and let each instance download
+                  # the other's patch. Generated here rather than exposed as an input, because an
+                  # input only protects callers who already know about this.
+                  echo "artifact_name=pre-commit-autofix-patch-$(openssl rand -hex 8)" | tee -a "$GITHUB_OUTPUT"
 
             # On the auto-fix path we lint the PR head itself, because the resulting patch is
             # committed back onto that branch. Elsewhere the default checkout (merge result on
@@ -142,7 +141,7 @@ jobs:
               if: steps.patch.outputs.has_fixes == 'true'
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
-                  name: ${{ inputs.autofix-artifact-name }}
+                  name: ${{ steps.mode.outputs.artifact_name }}
                   path: autofix.patch
                   # The patch is derived from pull request content, so it is no more sensitive
                   # than the PR itself. Kept briefly so a human can download exactly what the
@@ -170,7 +169,10 @@ jobs:
             - name: Download auto-fix patch
               uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
               with:
-                  name: ${{ inputs.autofix-artifact-name }}
+                  # Non-empty whenever this job runs: has_fixes can only be 'true' if the mode
+                  # step, which sets this, already ran. An empty name would download every
+                  # artifact of the run into per-name subdirectories.
+                  name: ${{ needs.lint.outputs.artifact_name }}
 
             - name: Check patch size
               # The patch content is untrusted: it was produced by repository-supplied hook code

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -51,6 +51,7 @@ jobs:
                   HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
                   BASE_REPO: ${{ github.repository }}
               run: |
+                  set -euo pipefail
                   # Auto-fix needs a privileged App token, so it is restricted to the designated
                   # bot actor AND to same-repository pull requests. A fork head is never checked
                   # out in the job that holds that token.
@@ -102,7 +103,7 @@ jobs:
 
             - name: Rerun pre-commit to autofix files if pre-commit failed
               uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-              if: always() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success'
+              if: ${{ !cancelled() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success' }}
               id: pre_commit_check_second_run
               with:
                   extra_args: --all-files --verbose
@@ -112,8 +113,8 @@ jobs:
             # and there is nothing to commit.
             - name: Produce auto-fix patch
               id: patch
-              if: always() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success' && steps.pre_commit_check_second_run.outcome
-                  == 'success'
+              if: ${{ !cancelled() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success' && steps.pre_commit_check_second_run.outcome
+                  == 'success' }}
               env:
                   MAX_BYTES: ${{ inputs.autofix-max-patch-bytes }}
               run: |
@@ -138,7 +139,10 @@ jobs:
                   echo "has_fixes=true" | tee -a "$GITHUB_OUTPUT"
 
             - name: Upload auto-fix patch
-              if: steps.patch.outputs.has_fixes == 'true'
+              # `!cancelled()` is required, not cosmetic: the first pre-commit run has failed
+              # by definition on every path that reaches here, so the implicit `success()` would
+              # skip this step and leave autofix-apply with no artifact to download.
+              if: ${{ !cancelled() && steps.patch.outputs.has_fixes == 'true' }}
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: ${{ steps.mode.outputs.artifact_name }}


### PR DESCRIPTION
Combines #546 and #547 into a single change. Both touched only
`.github/workflows/lint-global.yml` and conflicted with each other.

## Problem

`lint-global.yml` runs `pre-commit run --all-files`, which downloads and executes
third-party hook environments on the runner. On the auto-fix path, that happened in
the **same job** that held a GitHub App installation token with write access to the
repository:

- the token was passed to `actions/checkout`, which (default `persist-credentials: true`)
  wrote it into `.git/config` on disk **before** the hooks ran;
- even without that, hook code executing first can plant a `git` shim on `PATH`, a
  `BASH_ENV`, or a `.git/hooks` entry to intercept the token when the commit step runs.

Secondary issues: no `permissions:` block, so `GITHUB_TOKEN` inherited the caller's
write default for the entire run; the auto-fix checkout targeted
`github.event.pull_request.head.repo.full_name` — attacker-influenced event data — while
the token was live; and `github.actor` / `inputs.autofix-actor` were interpolated
directly into `run:`.

## Approach

Split the workflow in two jobs. Neither the hook code nor the token is ever in the same
job as the other.

| | `lint` | `autofix-apply` |
|---|---|---|
| runs `pre-commit` | yes | no |
| holds the App token | no | yes |
| output | patch artifact | signed commit |

`lint` runs the hooks with no credential and, if the second `pre-commit` pass fixed
things, uploads the diff as an artifact (`retention-days: 1`). `autofix-apply` starts on
a fresh runner, mints the token, checks out the head branch, applies the patch, and
commits it. It only starts when `lint` published `autofix_pr == 'true'` **and**
`has_fixes == 'true'`, so no token is minted when there is nothing to commit.

The commit is still created by `getsentry/action-github-commit`, i.e. through the GitHub
API, so it remains **signed/verified**. (#546 replaced it with `git commit && git push`,
which produces unsigned commits — `main` here has `required_signatures` enabled, and the
6 consumer repos have their own rules.) The patch is deliberately applied **unstaged**,
because that action collects files with `git ls-files -om`, which compares the working
tree against the index.

## Other changes (from #547)

- **`permissions: contents: read` at workflow level.** The auto-fix commit never used
  `GITHUB_TOKEN` — it uses the App token — so dropping to read costs nothing. Reusable-
  workflow semantics: a `permissions` block here can only be equal to or more restrictive
  than the caller's, so callers need no change.
- **`persist-credentials: false` on all three checkouts** — zizmor
  [`artipacked`](https://docs.zizmor.sh/audits/#artipacked). Nothing needs a git
  credential after checkout in either job.
- **Auto-fix gated on same-repository PRs.** The guard now also requires head repo ==
  base repo, so a fork head is never checked out in the job holding the token. In
  practice `renovate[bot]` never opens fork PRs; this removes the possibility rather
  than relying on it.
- **Actor/event comparison moved from `run:` interpolation into `env:`** — zizmor
  [`template-injection`](https://docs.zizmor.sh/audits/#template-injection).
- **Explicit `repositories:` on the token request** — zizmor
  [`github-app`](https://docs.zizmor.sh/audits/#github-app). Note: the composite action
  already defaults `repositories` to the current repository, so this is defence in depth
  against that default changing, not a fix for a live over-scope. #547's description
  claimed otherwise; that claim was wrong.
- **`getsentry/action-github-commit` comment retagged `# main` → `# v2.1.0`.** SHA
  unchanged and verified to be exactly `v2.1.0`; this only stops Renovate tracking a
  mutable branch tip.
- **Dropped the no-op `/./` in the `asdf-install-tooling` ref** — zizmor
  [`obfuscation`](https://docs.zizmor.sh/audits/#obfuscation), cosmetic.

## Size cap instead of #546's `.github/` refusal

#546 refused any patch touching `.github/`, on the grounds that a hostile hook could
smuggle a CI change into a bot commit that reviewers skim. That rule is not carried over:
renovate's main job in these repos *is* bumping action SHAs under `.github/workflows/`,
and `yamlfmt` reformatting those files is the single most common auto-fix, so it would
have broken the primary use case.

Replaced with a size cap. `autofix-apply` refuses a patch over **200 changed lines** or
**64 KiB**, both exposed as `workflow_call` inputs
(`autofix-max-changed-lines`, `autofix-max-patch-bytes`).

**What this buys, stated plainly:** it bounds a broken or runaway hook, and it blocks bulk
content (binaries, generated blobs) hiding behind a plausible commit message. It is *not*
an injection defence — a hostile hook would plant a handful of lines and sit far below any
threshold that is still usable. What it does do is keep the auto-fix commit inside the size
range where human review is actually effective: observed auto-fix commits are 2 lines, and
anything past 200 is handed back to a person.

**Correction — the review backstop is weaker than I first wrote here.** An earlier version
of this description said the patch "lands on a PR branch that requires review and one
approval". That is incomplete. `main` currently has:

```
required_approving_review_count: 1
dismiss_stale_reviews:           false
require_last_push_approval:      false
```

So an approval given *before* the auto-fix commit is not dismissed by it, and the auto-fix
content can reach `main` without anyone having read it. Renovate automerge was removed in
#542, so there is no auto-approval today, but the gap is in the branch protection, not in
the workflow. Tracked separately — setting `require_last_push_approval: true` is what makes
the claim true, and it is a repository setting, not something this PR can fix.

**Why 200.** Every auto-fix commit in this repository's history is 1 file / 4 changed
lines (3 of them, across ~200 merged PRs), so the default is roughly 50x the observed
maximum. The case that would exceed it is a formatter major bump reformatting the tree —
which fails loudly with instructions to run `pre-commit` locally, and is exactly the size
of change a human should be looking at.

The check runs in `autofix-apply`, where no hook code has executed and `git` can be
trusted. The `lint` job keeps a byte-only guard, explicitly *not* a security control,
purely so a runaway hook cannot make it upload a huge artifact and mint a token for a
patch that would be refused a minute later.

## Verification

- `zizmor --persona=auditor .github/workflows/lint-global.yml` → down to 2 findings
  (1 low, 1 medium), both pre-existing and both about the internal
  `generate-github-app-token-from-vault-secrets` action being pinned to a `main` commit.
  Was 8 (2 high, 4 medium, 2 low).
- `pre-commit run --files .github/workflows/lint-global.yml` → all hooks pass, including
  `actionlint`.
- Size-cap shell exercised locally against a patch mixing a text change, a binary add and
  a filename containing a space: `git apply --numstat` reports `-` for the binary hunk,
  which the line count skips and the byte count catches; both caps trip independently.
- Every `uses:` is pinned by commit SHA; `upload-artifact` and `download-artifact` SHAs
  verified against the `v4.6.2` / `v4.3.0` tags.

**The runtime auto-fix path has not been exercised.** It cannot be triggered from this
PR: the guard requires `github.actor == renovate[bot]`. It needs a throwaway Renovate PR
against a branch build before this is trusted in the consumer repos.

## Follow-ups (not in this PR)

- **Callers pin this workflow by SHA, so merging this does not fix them.** Each of the 6
  consumer repos needs its own bump once a tag is cut. One is several minor versions
  behind and needs a larger jump.
- `camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets` is
  still pinned to a `main` commit rather than a release tag. It is SHA-pinned, so it is
  immutable; the current pin (2026-08-01) is newer than the latest per-action tag
  (`generate-github-app-token-from-vault-secrets-1.1.0`), so switching would be a
  downgrade. Left alone deliberately.
- `getsentry/action-github-commit` reads file contents as UTF-8 and hardcodes mode
  `100644`, so it corrupts binary files and drops exec bits. Pre-existing, unchanged
  here, worth its own look.
- `zizmor` across the rest of `.github/` reports 227 findings. Out of scope; worth its
  own PR, and worth adding as a pre-commit hook afterwards.

Supersedes #546 and #547 — leaving both open for a human to close.
