### PR TITLE
ci: add zizmor to pre-commit, move actionlint back to upstream

### DIFF
--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -36,7 +36,7 @@ runs:
           id: detect-arch
           shell: bash
           run: |
-              if [[ "${{ inputs.arch }}" == "auto" ]]; then
+              if [[ "${INPUTS_ARCH}" == "auto" ]]; then
                 ARCH=$(uname -m)
                 case "$ARCH" in
                   x86_64) ARCH="amd64" ;;
@@ -45,9 +45,11 @@ runs:
                 esac
                 echo "Detected architecture: $ARCH"
               else
-                ARCH="${{ inputs.arch }}"
+                ARCH="${INPUTS_ARCH}"
               fi
               echo "arch=$ARCH" | tee -a "$GITHUB_OUTPUT"
+          env:
+              INPUTS_ARCH: ${{ inputs.arch }}
 
         - name: Compute cache key
           id: cache-key
@@ -58,7 +60,7 @@ runs:
               COMBINED_HASHES=""
 
               # Loop over each .tool-versions file, generate a hash for each one, and combine them
-              IFS=',' read -r -a tool_versions_files <<< "${{ inputs.tool_versions_files }}"
+              IFS=',' read -r -a tool_versions_files <<< "${INPUTS_TOOL_VERSIONS_FILES}"
               for tool_file in "${tool_versions_files[@]}"; do
                 if [ -f "$tool_file" ]; then
                   FILE_HASH=$(sha256sum "$tool_file" | awk '{print $1}')
@@ -69,9 +71,12 @@ runs:
               # Now generate a final hash of the combined hashes (this is the "hash of hashes")
               FINAL_HASH=$(echo -n "$COMBINED_HASHES" | sha256sum | awk '{print $1}')
 
-              echo "cache_key=${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}-${{ inputs.version }}-tooling-${FINAL_HASH}-week-${WEEK_NUMBER}" | tee -a "$GITHUB_OUTPUT"
+              echo "cache_key=${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}-${INPUTS_VERSION}-tooling-${FINAL_HASH}-week-${WEEK_NUMBER}" | tee -a "$GITHUB_OUTPUT"
               echo "cache_asdf_path=$HOME/.asdf" | tee -a "$GITHUB_OUTPUT"
               echo "cache_asdf_bin_path=$HOME/.local/bin/asdf" | tee -a "$GITHUB_OUTPUT"
+          env:
+              INPUTS_TOOL_VERSIONS_FILES: ${{ inputs.tool_versions_files }}
+              INPUTS_VERSION: ${{ inputs.version }}
 
         - name: Check if asdf cache exists
           id: cache-asdf-check
@@ -105,11 +110,11 @@ runs:
               set -euxo pipefail
 
               # Variables
-              FILE_NAME="asdf-${{ inputs.version }}-${{ inputs.os }}-${{ steps.detect-arch.outputs.arch }}.tar.gz"
-              DOWNLOAD_URL="https://github.com/asdf-vm/asdf/releases/download/${{ inputs.version }}/${FILE_NAME}"
+              FILE_NAME="asdf-${INPUTS_VERSION}-${INPUTS_OS}-${{ steps.detect-arch.outputs.arch }}.tar.gz"
+              DOWNLOAD_URL="https://github.com/asdf-vm/asdf/releases/download/${INPUTS_VERSION}/${FILE_NAME}"
               MD5_URL="${DOWNLOAD_URL}.md5"
 
-              echo "Installing asdf ${{ inputs.version }} ($DOWNLOAD_URL)"
+              echo "Installing asdf ${INPUTS_VERSION} ($DOWNLOAD_URL)"
 
               # Update destination
               mkdir -p "$HOME/.local/bin"
@@ -125,10 +130,16 @@ runs:
               # Extract and install
               tar -xzf /tmp/asdf.tar.gz -C "$HOME/.local/bin"
               chmod +x "$HOME/.local/bin/asdf"
+          env:
+              INPUTS_VERSION: ${{ inputs.version }}
+              INPUTS_OS: ${{ inputs.os }}
 
         - name: Add asdf path to the action path
           shell: bash
-          run: |
+          # Putting asdf on PATH is the whole point of this action. Both values are fixed
+          # paths derived from $HOME, not from action inputs or event data, so there is no
+          # attacker-controlled component to smuggle in here.
+          run: | # zizmor: ignore[github-env]
               echo "$HOME/.local/bin" | tee -a "$GITHUB_PATH"
               echo "${ASDF_DATA_DIR:-$HOME/.asdf}/shims" | tee -a "$GITHUB_PATH"
 
@@ -141,7 +152,7 @@ runs:
 
               asdf current
 
-              IFS=',' read -r -a tool_versions_files <<< "${{ inputs.tool_versions_files }}"
+              IFS=',' read -r -a tool_versions_files <<< "${INPUTS_TOOL_VERSIONS_FILES}"
               for tool_file in "${tool_versions_files[@]}"; do
                 if [ -f "$tool_file" ]; then
                   tool_file_dir=$(dirname "$tool_file")
@@ -177,6 +188,7 @@ runs:
               done
           env:
               ASDF_PYTHON_EXTRA_CONFIGURE_OPTIONS: --with-lzma
+              INPUTS_TOOL_VERSIONS_FILES: ${{ inputs.tool_versions_files }}
 
         - name: Cache installed tools
           id: cache-tools

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -45,7 +45,7 @@ runs:
           run: |
               # Extract owner, repo, and run_id from the URL
               # Expected format: https://github.com/owner/repo/actions/runs/run_id
-              url="${{ inputs.run_url }}"
+              url="${INPUTS_RUN_URL}"
 
               if [[ ! "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/actions/runs/([0-9]+) ]]; then
                 echo "Error: Invalid GitHub Actions URL format"
@@ -65,6 +65,8 @@ runs:
               echo "  Owner: $owner"
               echo "  Repository: $repo"
               echo "  Run ID: $run_id"
+          env:
+              INPUTS_RUN_URL: ${{ inputs.run_url }}
 
         - name: Wait for worfklow run to finish
           shell: bash

--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -97,7 +97,7 @@ runs:
           shell: bash
           continue-on-error: true
           run: |
-              ISSUE_TITLE="silence: ${{ github.workflow }}"
+              ISSUE_TITLE="silence: ${GITHUB_WORKFLOW}"
               ISSUE_SEARCH=$(gh issue list --repo ${{ github.repository }} --state open --search "$ISSUE_TITLE in:title" --label "alert-management" --json number,title,url)
               ISSUE_COUNT=$(echo "$ISSUE_SEARCH" | jq '. | length')
 
@@ -317,10 +317,11 @@ runs:
               gh workflow run "GHA Failure Log Analyzer" \
                 --repo camunda/infraex-common-config \
                 --field run_url="${{ env.WORKFLOW_URL }}" \
-                --field slack_channel_id="${{ inputs.slack_channel_id }}" \
+                --field slack_channel_id="${INPUTS_SLACK_CHANNEL_ID}" \
                 --field slack_thread_ts="${{ steps.slack-notification.outputs.ts }}"
 
               echo "GHA Failure Log Analyzer triggered successfully"
           env:
               GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
               WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              INPUTS_SLACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}

--- a/.github/workflows/automerge-global.yml
+++ b/.github/workflows/automerge-global.yml
@@ -37,10 +37,10 @@ jobs:
                   : # we don't rely on github.actor as it's the latest person to schedule/trigger the workflow.
                   pr_author="$(gh pr view ${{ github.event.pull_request.number }} --json author --jq '.author.login')"
 
-                  if [ "$pr_author" = "${{ inputs.author-name }}" ]; then
+                  if [ "$pr_author" = "${INPUTS_AUTHOR_NAME}" ]; then
                     echo "skip=false" | tee -a "$GITHUB_ENV"
                   else
-                    echo "This PR was not created by ${{ inputs.author-name }}, skipping auto approval."
+                    echo "This PR was not created by ${INPUTS_AUTHOR_NAME}, skipping auto approval."
                     echo "skip=true" | tee -a "$GITHUB_ENV"
                     exit 0
                   fi
@@ -56,6 +56,7 @@ jobs:
                   fi
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  INPUTS_AUTHOR_NAME: ${{ inputs.author-name }}
 
             - name: Wait for other checks to succeed
               uses: poseidon/wait-for-status-checks@e7e24423722c5b8e97a6dd5848827d2a412f812d # v0.7.0

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -134,8 +134,8 @@ jobs:
               id: determine-values
               run: |
                   if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-                      AWS_REGION="${{ github.event.inputs.region }}"
-                      CLEANUP_OLDER_THAN="${{ github.event.inputs.cleanup_older_than }}"
+                      AWS_REGION="${GITHUB_EVENT_INPUTS_REGION}"
+                      CLEANUP_OLDER_THAN="${GITHUB_EVENT_INPUTS_CLEANUP_OLDER_THAN}"
                   else
                       AWS_REGION="${{ matrix.config.region }}"
                       CLEANUP_OLDER_THAN="${{ matrix.config.cleanup_older_than }}"
@@ -143,6 +143,9 @@ jobs:
 
                   echo "AWS_REGION=$AWS_REGION" | tee -a "$GITHUB_ENV"
                   echo "CLEANUP_OLDER_THAN=$CLEANUP_OLDER_THAN" | tee -a "$GITHUB_ENV"
+              env:
+                  GITHUB_EVENT_INPUTS_REGION: ${{ github.event.inputs.region }}
+                  GITHUB_EVENT_INPUTS_CLEANUP_OLDER_THAN: ${{ github.event.inputs.cleanup_older_than }}
 
             - name: Check if job should run based on the day
               id: day-check

--- a/.github/workflows/azure_nightly_cleanup.yml
+++ b/.github/workflows/azure_nightly_cleanup.yml
@@ -2,7 +2,7 @@
 name: Azure Scheduled Cleanup of test regions
 
 permissions:
-    id-token: write
+    contents: read
 
 on:
     schedule:
@@ -30,6 +30,11 @@ concurrency:
 jobs:
     azure-cleanup:
         runs-on: ubuntu-latest
+        # `azure/login` authenticates with OIDC, so this job — and only this job — needs to
+        # mint an OIDC token. Vault is reached with AppRole, which needs no extra permission.
+        permissions:
+            contents: read
+            id-token: write
         strategy:
             fail-fast: false # don't propagate failing jobs
             matrix:
@@ -50,8 +55,8 @@ jobs:
               id: determine-values
               run: |
                   if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-                      AZURE_REGION="${{ github.event.inputs.region }}"
-                      CLEANUP_OLDER_THAN="${{ github.event.inputs.cleanup_older_than }}"
+                      AZURE_REGION="${GITHUB_EVENT_INPUTS_REGION}"
+                      CLEANUP_OLDER_THAN="${GITHUB_EVENT_INPUTS_CLEANUP_OLDER_THAN}"
                   else
                       AZURE_REGION="${{ matrix.config.region }}"
                       CLEANUP_OLDER_THAN="${{ matrix.config.cleanup_older_than }}"
@@ -59,6 +64,9 @@ jobs:
 
                   echo "AZURE_REGION=$AZURE_REGION" | tee -a "$GITHUB_ENV"
                   echo "CLEANUP_OLDER_THAN=$CLEANUP_OLDER_THAN" | tee -a "$GITHUB_ENV"
+              env:
+                  GITHUB_EVENT_INPUTS_REGION: ${{ github.event.inputs.region }}
+                  GITHUB_EVENT_INPUTS_CLEANUP_OLDER_THAN: ${{ github.event.inputs.cleanup_older_than }}
 
             - name: Check if job should run based on the day
               id: day-check
@@ -127,6 +135,9 @@ jobs:
 
     notify-on-failure:
         runs-on: ubuntu-latest
+        # The Slack action talks to GitHub with a Vault-issued App token, not GITHUB_TOKEN.
+        permissions:
+            contents: read
         if: failure()
         needs:
             - azure-cleanup

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -85,15 +85,6 @@ jobs:
               with:
                   persist-credentials: false
 
-            - name: Centralized Actionlint
-              uses: camunda/infra-global-github-actions/actionlint@70856595c361916264dc0ca86084200a68da48f5 # actionlint-1.0.3
-              with:
-                  # Kept in step with the actionlint pinned in .pre-commit-config.yaml. Letting
-                  # the action's own default apply would run a different version here than
-                  # locally, so a workflow could pass on one side and fail on the other.
-                  # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v(?<version>.*)$
-                  version: 1.7.12
-
             # Required for pre-commit to work with Python referenced in .tool-versions for Ubuntu >= 24.04
             - name: Install Python dependencies
               run: |

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -85,9 +85,14 @@ jobs:
               with:
                   persist-credentials: false
 
-            # TODO: Renable when switching back to upstream actionlint
-            # - name: Centralized Actionlint
-            #   uses: camunda/infra-global-github-actions/actionlint@4c0c3611b80ac8e147f7991092a0e282b52c48fa # main
+            - name: Centralized Actionlint
+              uses: camunda/infra-global-github-actions/actionlint@70856595c361916264dc0ca86084200a68da48f5 # actionlint-1.0.3
+              with:
+                  # Kept in step with the actionlint pinned in .pre-commit-config.yaml. Letting
+                  # the action's own default apply would run a different version here than
+                  # locally, so a workflow could pass on one side and fail on the other.
+                  # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v(?<version>.*)$
+                  version: 1.7.12
 
             # Required for pre-commit to work with Python referenced in .tool-versions for Ubuntu >= 24.04
             - name: Install Python dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,15 @@ repos:
       rev: 0.2.3
       hooks:
           - id: yamlfmt
+
+    - repo: https://github.com/zizmorcore/zizmor-pre-commit
+      rev: v1.29.0
+      hooks:
+          # Static analysis of GitHub Actions workflows and actions.
+          # Threshold is `high` because the repository still carries ~30 medium and ~55
+          # low/informational findings; see the burn-down issue before lowering it.
+          # Without GH_TOKEN zizmor runs offline, which skips known-vulnerable-actions,
+          # impostor-commit, ref-confusion, ref-version-mismatch and stale-action-refs.
+          # None of those currently report anything at `high`.
+          - id: zizmor
+            args: [--no-progress, --min-severity=high]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
           - id: end-of-file-fixer
           - id: check-added-large-files
 
-    - repo: https://github.com/mattleibow/actionlint
-      rev: 7b6f502befda0d99dcb5a1cf8cf72d792bfa7c8a
+    - repo: https://github.com/rhysd/actionlint
+      rev: v1.7.12
       hooks:
           - id: actionlint
             args: [-ignore=SC2155]


### PR DESCRIPTION
Rebased onto `main` now that #550 has landed. Base retargeted from #550's branch to `main`.

This PR now carries three things. The first is its original subject; the other two arrived
as #554 and #555, both reviewed and merged into this branch while it was stacked.

---

## 1. zizmor in pre-commit, and its high-severity findings fixed

`zizmorcore/zizmor-pre-commit` plugs straight into `.pre-commit-config.yaml`, so it runs
locally and in CI with no new job.

The baseline was not clean — `zizmor .github/` on `main` reported 106 findings (21 high,
30 medium, 55 low/informational), and no `--min-severity` threshold was green. So the hook
is gated at `--min-severity=high` and the 21 high findings are fixed here:

- **`template-injection` × 18.** `${{ … }}` expanded directly into `run:` bodies, where
  GitHub substitutes before the shell parses, so a value with shell metacharacters becomes
  code. All now passed through `env:`. Applied with `zizmor --fix=all`, reviewed one by
  one. Expansions zizmor treats as non-controllable (`runner.os`, `matrix.config.*`,
  `steps.*.outputs.*`) were deliberately left alone.
- **`excessive-permissions` × 1.** `azure_nightly_cleanup.yml` declared `id-token: write`
  at *workflow* level, handing OIDC token minting to `notify-on-failure`, which never uses
  it. Moved to `azure-cleanup`, the only job running `azure/login`; workflow level is now
  `contents: read`. Checked the rest of that workflow needs nothing more — Vault is reached
  with AppRole, and `report-failure-on-slack` uses a Vault-issued App token, not
  `GITHUB_TOKEN`.
- **`github-env` × 2.** Suppressed, not fixed. `asdf-install-tooling` writes to
  `GITHUB_PATH`; that is the action's purpose and both values are fixed paths derived from
  `$HOME`. zizmor rates it Low confidence itself. Suppressed inline with the reasoning
  beside it rather than in a config file.

Remaining below the threshold: ~30 medium, ~55 low. The threshold is the burn-down knob.

**Offline, deliberately.** Without a token zizmor skips `known-vulnerable-actions`,
`impostor-commit`, `ref-confusion`, `ref-version-mismatch` and `stale-action-refs`. I
measured before deciding: offline and online report **exactly the same 21 high findings**
on `main`, so the online-only audits contribute nothing at this threshold. Passing
`GH_TOKEN` to the `pre-commit` step would hand a repository token to third-party hook code
— the exposure #550 exists to remove — for all 6 consumer repositories. Left as a
follow-up: the right shape is a separate job holding no hook code.

## 2. actionlint back to upstream (was #554)

`.pre-commit-config.yaml` moves from `mattleibow/actionlint@7b6f502` to
`rhysd/actionlint` `v1.7.12`.

That fork was a temporary workaround from #293 (August 2025): actionlint did not yet know
GitHub's `models:` permission, and this repository declares one in
`gha-failure-log-analyzer.yml`. Upstream added it in `5d41b3d4` (2025-04-11), refined it in
`9510b014`, and has shipped it since v1.7.10. Verified rather than assumed:

```
$ docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.12 -ignore=SC2155
exit=0, 0 findings
```

Worth doing beyond closing the TODO: the fork pin sat at `ahead 1, behind 332` commits of
upstream, last pushed 2025-09-21, on a personal repository with no releases — and the hook
is `language: golang`, so `pre-commit` was compiling it from source on every developer
machine and in CI. All five other consumers of `lint-global.yml` were already on upstream;
this repository was the last one anywhere still on the fork.

## 3. The centralized actionlint step stays off (was #555)

#554 also re-enabled the `Centralized Actionlint` step that #293 had commented out. #555
removed it again, and removed the stale commented block with it.

The shared action installs itself with

```bash
bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $ACTIONLINT_VERSION
```

— a mutable branch ref, no `-f`, piped into `bash`; the script it runs then does
`curl -L | tar xvz` on the release tarball with no checksum. Three unverified fetches, in
the job whose output `autofix-apply` commits with a GitHub App token. Raised as
camunda/infra-global-github-actions#778.

The step is also redundant here. Five of the six consumers already run actionlint from
their own pre-commit config, all on upstream. The sixth,
`camunda/team-infrastructure-experience`, has 19 workflows and no actionlint at all — a
real gap, but one that has been open since August 2025 anyway and is fixed by one line in
*that* repository, not by reinstating a `curl | bash` step for all six. Filed as
camunda/team-infrastructure-experience#1223.

## Verification

- `pre-commit run --all-files` → green, including the new `zizmor` hook and the rebuilt
  upstream `actionlint` hook.
- `zizmor --min-severity=high .github/` → clean.
