### PR TITLE
security: pin the toolchain the README pre-commit hook executes

### DIFF
--- a/pre_commit_hooks/docker_update_action_readmes.sh
+++ b/pre_commit_hooks/docker_update_action_readmes.sh
@@ -24,10 +24,14 @@ TOP_ACTION_DIR=".github/actions"
 #   whatever npm served at run time;
 # - --ignore-scripts, so a compromised release cannot execute install hooks.
 #
-# renovate: datasource=docker depName=node versioning=docker
+# In `node:TAG@DIGEST` the digest is what is actually resolved; the tag is decorative.
+# So the two are one unit and are updated together, by hand, deliberately: a Renovate
+# annotation on the tag alone would let it advance while the digest — and therefore the
+# image that really runs — stayed put, leaving the file describing something untrue.
+#
+# To move to a newer node, refresh both:
+#   docker buildx imagetools inspect node:<tag> --format '{{.Manifest.Digest}}'
 NODE_IMAGE="node:22"
-# The custom managers in default.json5 track the tag, not the digest, so refresh this by
-# hand whenever the tag above moves: docker manifest inspect "$NODE_IMAGE"
 NODE_IMAGE_DIGEST="sha256:0557ac14e0d45d02ed563067b82856ca5e7aa3437fa28d98d4350ea9c3d9494a"
 # renovate: datasource=npm depName=action-docs
 ACTION_DOCS_VERSION="2.5.1"

--- a/pre_commit_hooks/docker_update_action_readmes.sh
+++ b/pre_commit_hooks/docker_update_action_readmes.sh
@@ -16,6 +16,22 @@ DOC_ACTION_VERSION=${DOC_ACTION_VERSION:-main}
 # directory where your actions are located, use "." if it's top directory
 TOP_ACTION_DIR=".github/actions"
 
+# This hook writes into the working tree, and on the auto-fix path its output is committed
+# back to the pull request by CI. Everything it executes is therefore pinned:
+#
+# - the image by digest, so the tag cannot be repointed under us;
+# - action-docs to an exact version, because `npm install -g action-docs` resolved
+#   whatever npm served at run time;
+# - --ignore-scripts, so a compromised release cannot execute install hooks.
+#
+# renovate: datasource=docker depName=node versioning=docker
+NODE_IMAGE="node:22"
+# The custom managers in default.json5 track the tag, not the digest, so refresh this by
+# hand whenever the tag above moves: docker manifest inspect "$NODE_IMAGE"
+NODE_IMAGE_DIGEST="sha256:0557ac14e0d45d02ed563067b82856ca5e7aa3437fa28d98d4350ea9c3d9494a"
+# renovate: datasource=npm depName=action-docs
+ACTION_DOCS_VERSION="2.5.1"
+
 # Run a single Docker container to handle the README.md updates
 docker run --rm \
     -e USER_ID="$USER_ID" \
@@ -23,12 +39,13 @@ docker run --rm \
     -e DOC_ACTION_VERSION="$DOC_ACTION_VERSION" \
     -e OWNER_PROJECT="$OWNER_PROJECT" \
     -e TOP_ACTION_DIR="$TOP_ACTION_DIR" \
+    -e ACTION_DOCS_VERSION="$ACTION_DOCS_VERSION" \
     -v "$PWD":/workspace \
     -w /workspace \
-    node:22 \
+    "${NODE_IMAGE}@${NODE_IMAGE_DIGEST}" \
     bash -c '
         set -euxo pipefail
-        npm install -g action-docs
+        npm install -g --ignore-scripts "action-docs@${ACTION_DOCS_VERSION}"
         find "$TOP_ACTION_DIR" -name "*.yml" -o -name "*.yaml" | while read -r action_file; do
             action_dir=$(dirname "$action_file")
             action_dir_top=$(basename "$action_dir")


### PR DESCRIPTION
Independent of #550 / #551. Based on `main`.

## Problem

`pre_commit_hooks/docker_update_action_readmes.sh` executes, on every run:

```bash
docker run --rm ... -v "$PWD":/workspace ... node:22 \
    bash -c 'npm install -g action-docs; ...'
```

`node:22` is a mutable tag. `action-docs` has no version at all — npm resolves whatever it
is serving at that moment. Both then run with the repository mounted read-write at
`/workspace`, and the hook's whole purpose is to rewrite files in it.

On the auto-fix path CI commits that output back to the pull request with a GitHub App
token. So the content of a bot commit is, today, whatever npm decided to publish.

**This is the hook that actually produces the auto-fix commits here.** Of the three
auto-fix commits in this repository's history, two are `asdf-install-tooling/README.md`
regenerations from this script — `bbe793f4` and `ed57ac7e`, both bumping a documented
default in a table. It is the hot path, not a corner case.

## Changes

```bash
NODE_IMAGE="node:22"
NODE_IMAGE_DIGEST="sha256:0557ac14e0d45d02ed563067b82856ca5e7aa3437fa28d98d4350ea9c3d9494a"
# renovate: datasource=npm depName=action-docs
ACTION_DOCS_VERSION="2.5.1"
```

- **Image by digest**, so the tag cannot be repointed underneath us.
- **`action-docs` at an exact version.**
- **`npm install --ignore-scripts`**, so a compromised release cannot execute
  `preinstall`/`postinstall` hooks. `action-docs` is a plain CLI and does not need them —
  verified it still runs.

`action-docs` carries a Renovate annotation and is picked up by the custom managers already
in `default.json5` (`.sh` is in `managerFilePatterns`).

The node image deliberately carries **no** annotation. In `node:TAG@DIGEST` the digest is
what resolves and the tag is decorative, so annotating the tag alone would let Renovate
advance it while the image actually executing stayed put — CI would pass precisely because
nothing changed, and the file would end up describing something untrue. Tag and digest are
therefore one manually-updated unit, with the refresh command in the comment.

## Verification

Running the pinned script regenerates every action README with **zero diff** — output is
byte-identical to the unpinned toolchain:

```
$ ./pre_commit_hooks/docker_update_action_readmes.sh
+ docker run --rm ... node:22@sha256:0557ac14e0d45... bash -c '
        npm install -g --ignore-scripts "action-docs@${ACTION_DOCS_VERSION}"

$ git diff --stat
 pre_commit_hooks/docker_update_action_readmes.sh | 21 +++++++++++++++++++--
```

`pre-commit run --all-files` green.

## Two caveats worth knowing

**1. This does not take effect until a tag is cut.** `.pre-commit-config.yaml` consumes
this repo's own hook as a *remote* repo at `rev: 1.8.0`, so `pre-commit` runs the script
from its cached clone of that tag, not from the working tree. I confirmed this the hard
way — my first validation run was silently executing the old, unpinned script out of
`~/.cache/pre-commit/`. The fix reaches this repo and the consumers only after a release
and a `rev:` bump.

**2. Pinning the top level is not the whole dependency tree.** `action-docs@2.5.1` still
resolves its own transitive dependencies at install time; there is no lockfile in play.
`--ignore-scripts` is what removes the sharpest edge (arbitrary code at install), not the
version pin. Stating that so nobody reads this as "the hook is now hermetic".

## Follow-ups

- Cut a release and bump `rev:` here and in the consumer repos, otherwise this changes
  nothing at runtime.
- Consider `npm ci` against a committed lockfile, or vendoring `action-docs`, if the
  transitive tree is a concern.
- A Renovate custom manager capturing `currentDigest` would let the node tag and digest be
  bumped together. It has to go either in the shared `default.json5`, which every consumer
  repo inherits, or in this repo's `.github/renovate.json5` — where a local
  `customManagers` array may *replace* the preset's rather than extend it and silently
  disable the other patterns. Worth verifying, not inside a security fix.
