### PR TITLE
ci: return actionlint to upstream and re-enable the centralized step

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -81,9 +81,14 @@ jobs:
               with:
                   persist-credentials: false
 
-            # TODO: Renable when switching back to upstream actionlint
-            # - name: Centralized Actionlint
-            #   uses: camunda/infra-global-github-actions/actionlint@4c0c3611b80ac8e147f7991092a0e282b52c48fa # main
+            - name: Centralized Actionlint
+              uses: camunda/infra-global-github-actions/actionlint@70856595c361916264dc0ca86084200a68da48f5 # actionlint-1.0.3
+              with:
+                  # Kept in step with the actionlint pinned in .pre-commit-config.yaml. Letting
+                  # the action's own default apply would run a different version here than
+                  # locally, so a workflow could pass on one side and fail on the other.
+                  # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v(?<version>.*)$
+                  version: 1.7.12
 
             # Required for pre-commit to work with Python referenced in .tool-versions for Ubuntu >= 24.04
             - name: Install Python dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
           - id: end-of-file-fixer
           - id: check-added-large-files
 
-    - repo: https://github.com/mattleibow/actionlint
-      rev: 7b6f502befda0d99dcb5a1cf8cf72d792bfa7c8a
+    - repo: https://github.com/rhysd/actionlint
+      rev: v1.7.12
       hooks:
           - id: actionlint
             args: [-ignore=SC2155]


### PR DESCRIPTION
> **Stacked on #551**, which is stacked on #550, because this touches both
> `.pre-commit-config.yaml` and `.github/workflows/lint-global.yml`. Retarget as those land.

Closes the TODO that #293 left in `lint-global.yml` in August 2025:

```yaml
# TODO: Renable when switching back to upstream actionlint
# - name: Centralized Actionlint
#   uses: camunda/infra-global-github-actions/actionlint@4c0c361 # main
```

## What that TODO was

GitHub added a `models:` permission. actionlint did not know it, so it errored on a
legitimate workflow — and this repository has one: `gha-failure-log-analyzer.yml`
declares `models: read`.

#293 ("chore: **tmp** switch to forked actionlint") worked around it on both sides: the
pre-commit hook moved to `mattleibow/actionlint`, a fork carrying "Add support for
`models` permissions", and the centralized step, which used upstream, was commented out.
The PR said so explicitly:

> I'm temporarily switching to the forked actionlint that has the models change included
> […] I'm subscribed to the upstream issue and PR in case it should move forward.

At the time the fix existed on upstream `main` but was in no release, so the wait was
justified.

## Why it can close now

| | |
|---|---|
| upstream support | `rule_permissions.go`: `"models": {"read", "none"}` |
| added | `5d41b3d4`, 2025-04-11 — refined in `9510b014`, 2025-10-12 |
| released since | v1.7.10, v1.7.11, **v1.7.12** |

Verified against this repository's actual workflows rather than assumed:

```
$ docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.12 -ignore=SC2155
exit=0
findings: 0
```

`models: read` included.

## Why it is worth closing now

The fork pin was not standing still relative to upstream:

```
rhysd/actionlint main...7b6f502  ->  ahead 1, behind 332
```

332 commits behind, roughly a year of rules and fixes. `mattleibow/actionlint` is a
personal fork with no releases, last pushed 2025-09-21. And the hook is
`language: golang`, so `pre-commit` was **compiling that fork from source** on every
developer machine and in CI. Same family as #552.

## The trap in re-enabling the step

The commented-out pin, `4c0c361`, defaults to **actionlint 1.7.4**. Uncommenting it as it
stood would have reintroduced the exact `models:` failure the TODO was created for.

So the step is re-pinned to the **`actionlint-1.0.3` tag** (`7085659`, default 1.7.10)
rather than a `main` commit, and given an explicit `version: 1.7.12` matching the
pre-commit hook — otherwise CI and local would lint with different actionlints and a
workflow could pass on one side and fail on the other. Renovate annotation added so the
two do not drift.

## Something reviewers should know before approving

Re-enabling this step means every lint run, in all 6 consumer repositories, executes:

```bash
bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $ACTIONLINT_VERSION
```

That is a script fetched from a **mutable branch ref**, with no checksum, piped straight
into `bash`. The script it runs then does `curl -L "${url}" | tar xvz` on the release
tarball, also unverified. Three unpinned fetches, in the job whose output #550 hands to a
privileged token in the next job.

In fairness this does not change the category: that job already installs and executes
third-party `pre-commit` hook environments, so it is not a clean room to begin with. But
it is one more unverified fetch, it lives in a **shared org action**, and it is exactly
what #552 just removed from the README hook. Raised upstream separately — it needs fixing
in `camunda/infra-global-github-actions`, not here.

Dropping the step again is a one-commit change if reviewers prefer that. But **not** a
free one, and I initially wrote here that it was — correcting that.

The two runs are complementary, not duplicate:

| | org self-hosted runner labels | shellcheck |
|---|---|---|
| `Centralized Actionlint` | yes, via `-config-file` | no (`use_shellcheck: false`) |
| `actionlint` pre-commit hook | no | yes, with `-ignore=SC2155` |

The action's `actionlint.yaml` declares the org's ~50 self-hosted runner labels
(`aws-core-8-default`, `gcp-core-32-release`, …). Without it, actionlint rejects those as
unknown labels. That is the reason the centralized action exists.

For *this* repository it happens not to matter — every workflow here is `ubuntu-latest`
and there is no `.github/actionlint.yaml` — so here the step really is redundant. But
`lint-global.yml` is consumed by 6 repositories, and any of them using self-hosted runners
gets that config only from this step. Which way to go is a call for whoever knows those
consumers.

## Verification

- `pre-commit run --all-files` → green, including the rebuilt upstream `actionlint` hook.
- `zizmor --min-severity=high .github/` → clean, so the re-enabled step adds no
  high-severity finding.
- `zizmor --persona=auditor .github/workflows/lint-global.yml` → unchanged at the 2
  pre-existing findings about the internal token action pinned to `main`.
