### PR TITLE
ci: drop the Centralized Actionlint step, keep upstream actionlint

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -81,15 +81,6 @@ jobs:
               with:
                   persist-credentials: false
 
-            - name: Centralized Actionlint
-              uses: camunda/infra-global-github-actions/actionlint@70856595c361916264dc0ca86084200a68da48f5 # actionlint-1.0.3
-              with:
-                  # Kept in step with the actionlint pinned in .pre-commit-config.yaml. Letting
-                  # the action's own default apply would run a different version here than
-                  # locally, so a workflow could pass on one side and fail on the other.
-                  # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v(?<version>.*)$
-                  version: 1.7.12
-
             # Required for pre-commit to work with Python referenced in .tool-versions for Ubuntu >= 24.04
             - name: Install Python dependencies
               run: |


### PR DESCRIPTION
> **Stacked on #551**, which is stacked on #550. Retarget as those land.

Partial revert of #554, which is already merged into `security/zizmor-pre-commit`.

**Kept:** the pre-commit hook stays on upstream `rhysd/actionlint` at `v1.7.12`, off the
`mattleibow` fork.

**Removed:** the `Centralized Actionlint` step — entirely, not commented out.

## The step is redundant, checked rather than assumed

Every repository consuming `lint-global.yml`, and what it already runs:

| repository | actionlint hook | `.github/actionlint.yaml` |
|---|---|---|
| `camunda/keycloak` | `rhysd/actionlint` v1.7.12, `actionlint-docker` | yes |
| `camunda/c8-multi-region` | `rhysd/actionlint` v1.7.10, `actionlint` | no |
| `camunda/camunda-deployment-references` | `rhysd/actionlint` v1.7.12, `actionlint-docker` | yes |
| `camunda/c8-sm-checks` | `rhysd/actionlint` v1.7.12, `actionlint-docker` | no |
| `camunda/infraex-terraform` | `rhysd/actionlint` v1.7.12, `actionlint-docker` | yes |
| `camunda/team-infrastructure-experience` | **none** | no |

Two things fall out of that table.

**All five are already on upstream `rhysd/actionlint`.** This repository was the last one
anywhere still pinned to the `mattleibow` fork; #554 closed that. There was never a fleet
to migrate.

**The `-config-file` argument is thinner than I claimed earlier in this stack.** Its value
is distributing the organisation's self-hosted runner labels. But actionlint loads
`.github/actionlint.yaml` natively, and three of the six already have one — the
repositories that need those labels have solved it locally, without the action.

## The one real gap, and why this is not the fix for it

`camunda/team-infrastructure-experience` has 19 workflows and no actionlint at all. That
is a genuine hole — and it has been open since August 2025, because the step this PR
removes has been disabled that whole time. Removing it changes nothing for that repository.

The fix there is one line in its own `.pre-commit-config.yaml`, not reinstating a step for
all six that installs itself like this:

```bash
bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $ACTIONLINT_VERSION
```

Mutable branch ref, no `-f`, piped into `bash`; the script it runs then does
`curl -L | tar xvz` with no checksum. Three unverified fetches in the job whose output
`autofix-apply` commits with a GitHub App token. Raised as
camunda/infra-global-github-actions#778.

## Why no commented-out block

An earlier revision of this PR left the verified configuration behind as a comment. That
was the wrong instinct: commented code rots, and "we might switch this back on" belongs in
the issue tracker. The pin and version that were verified to work are recorded in #778 and
in the history of #554 if the decision is ever revisited.

## Verification

- `pre-commit run --all-files` → green, upstream `actionlint` hook included.
- `zizmor --min-severity=high .github/` → clean.
