### PR TITLE
security: stop laundering caller input through step outputs [ready]

### DIFF
--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -46,6 +46,14 @@ runs:
                 echo "Detected architecture: $ARCH"
               else
                 ARCH="${INPUTS_ARCH}"
+                # Validated here rather than at each use: this value is written to
+                # $GITHUB_OUTPUT and read back by two later steps, so a newline in it would
+                # define extra step outputs, and a shell metacharacter would travel with it.
+                # Constraining it once at the source makes every consumer safe.
+                if [[ ! "$ARCH" =~ ^[A-Za-z0-9_-]+$ ]]; then
+                  echo "Invalid 'arch' input: expected [A-Za-z0-9_-]+, got: ${ARCH}" >&2
+                  exit 1
+                fi
               fi
               echo "arch=$ARCH" | tee -a "$GITHUB_OUTPUT"
           env:

--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -83,9 +83,9 @@ runs:
               echo "cache_asdf_path=$HOME/.asdf" | tee -a "$GITHUB_OUTPUT"
               echo "cache_asdf_bin_path=$HOME/.local/bin/asdf" | tee -a "$GITHUB_OUTPUT"
           env:
-              # detect-arch echoes `inputs.arch` back out verbatim when it is not "auto", so this
-              # output is as caller-controlled as the input is. Expanding it into the script
-              # would undo the point of routing `inputs.arch` through env in the first place.
+              # This output carries `inputs.arch` whenever the caller supplied one. detect-arch
+              # constrains it to [A-Za-z0-9_-]+, and passing it through env keeps it out of the
+              # script text regardless — the two together, not either alone.
               DETECTED_ARCH: ${{ steps.detect-arch.outputs.arch }}
               INPUTS_TOOL_VERSIONS_FILES: ${{ inputs.tool_versions_files }}
               INPUTS_VERSION: ${{ inputs.version }}

--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -32,10 +32,22 @@ inputs:
 runs:
     using: composite
     steps:
-        - name: Detect architecture if auto
+        - name: Validate inputs and detect architecture
           id: detect-arch
           shell: bash
           run: |
+              # Every input below ends up either in $GITHUB_OUTPUT, which is line-oriented, or
+              # in a download URL. Checking them here, once, is what keeps each consumer safe;
+              # sanitising per use means remembering to do it again next time one is added.
+              if [[ ! "${INPUTS_VERSION}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+                echo "Invalid 'version' input: expected [A-Za-z0-9._-]+, got: ${INPUTS_VERSION}" >&2
+                exit 1
+              fi
+              if [[ ! "${INPUTS_OS}" =~ ^(linux|darwin)$ ]]; then
+                echo "Invalid 'os' input: expected linux or darwin, got: ${INPUTS_OS}" >&2
+                exit 1
+              fi
+
               if [[ "${INPUTS_ARCH}" == "auto" ]]; then
                 ARCH=$(uname -m)
                 case "$ARCH" in
@@ -58,6 +70,8 @@ runs:
               echo "arch=$ARCH" | tee -a "$GITHUB_OUTPUT"
           env:
               INPUTS_ARCH: ${{ inputs.arch }}
+              INPUTS_OS: ${{ inputs.os }}
+              INPUTS_VERSION: ${{ inputs.version }}
 
         - name: Compute cache key
           id: cache-key

--- a/.github/actions/asdf-install-tooling/action.yml
+++ b/.github/actions/asdf-install-tooling/action.yml
@@ -71,10 +71,14 @@ runs:
               # Now generate a final hash of the combined hashes (this is the "hash of hashes")
               FINAL_HASH=$(echo -n "$COMBINED_HASHES" | sha256sum | awk '{print $1}')
 
-              echo "cache_key=${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}-${INPUTS_VERSION}-tooling-${FINAL_HASH}-week-${WEEK_NUMBER}" | tee -a "$GITHUB_OUTPUT"
+              echo "cache_key=${RUNNER_OS}-${DETECTED_ARCH}-${INPUTS_VERSION}-tooling-${FINAL_HASH}-week-${WEEK_NUMBER}" | tee -a "$GITHUB_OUTPUT"
               echo "cache_asdf_path=$HOME/.asdf" | tee -a "$GITHUB_OUTPUT"
               echo "cache_asdf_bin_path=$HOME/.local/bin/asdf" | tee -a "$GITHUB_OUTPUT"
           env:
+              # detect-arch echoes `inputs.arch` back out verbatim when it is not "auto", so this
+              # output is as caller-controlled as the input is. Expanding it into the script
+              # would undo the point of routing `inputs.arch` through env in the first place.
+              DETECTED_ARCH: ${{ steps.detect-arch.outputs.arch }}
               INPUTS_TOOL_VERSIONS_FILES: ${{ inputs.tool_versions_files }}
               INPUTS_VERSION: ${{ inputs.version }}
 
@@ -110,7 +114,7 @@ runs:
               set -euxo pipefail
 
               # Variables
-              FILE_NAME="asdf-${INPUTS_VERSION}-${INPUTS_OS}-${{ steps.detect-arch.outputs.arch }}.tar.gz"
+              FILE_NAME="asdf-${INPUTS_VERSION}-${INPUTS_OS}-${DETECTED_ARCH}.tar.gz"
               DOWNLOAD_URL="https://github.com/asdf-vm/asdf/releases/download/${INPUTS_VERSION}/${FILE_NAME}"
               MD5_URL="${DOWNLOAD_URL}.md5"
 
@@ -131,6 +135,7 @@ runs:
               tar -xzf /tmp/asdf.tar.gz -C "$HOME/.local/bin"
               chmod +x "$HOME/.local/bin/asdf"
           env:
+              DETECTED_ARCH: ${{ steps.detect-arch.outputs.arch }}
               INPUTS_VERSION: ${{ inputs.version }}
               INPUTS_OS: ${{ inputs.os }}
 

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -47,10 +47,11 @@ runs:
               # Expected format: https://github.com/owner/repo/actions/runs/run_id
               url="${INPUTS_RUN_URL}"
 
-              # owner and repo are constrained to GitHub's own naming rules rather than "[^/]+".
-              # They are written to $GITHUB_OUTPUT and later used as command arguments, so a
-              # newline would define extra step outputs and a metacharacter would travel with
-              # them. Validating the capture is simpler than sanitising every consumer.
+              # The capture groups are a conservative charset, not GitHub's exact naming rules:
+              # they still admit shapes GitHub would reject, such as a leading hyphen. What they
+              # do guarantee is the part that matters here — no newline, no whitespace, no shell
+              # metacharacter — because these values are written to $GITHUB_OUTPUT, which is
+              # line-oriented, and later passed as command arguments.
               if [[ ! "$url" =~ ^https://github\.com/([A-Za-z0-9-]+)/([A-Za-z0-9._-]+)/actions/runs/([0-9]+) ]]; then
                 echo "Error: Invalid GitHub Actions URL format"
                 echo "Expected format: https://github.com/owner/repo/actions/runs/run_id"
@@ -106,7 +107,9 @@ runs:
               echo "Listing logs directory contents:"
               ls -lh logs
 
-              LOG_CONTENT="$(cat logs/trimmed_50kb.log | tr -d '\n')"
+              # Both CR and LF: the value is written to the line-oriented $GITHUB_OUTPUT, and
+              # this is log text from an arbitrary workflow run, so it is not trusted input.
+              LOG_CONTENT="$(tr -d '\r\n' < logs/trimmed_50kb.log)"
               echo "Downsized log file size: $(echo "$LOG_CONTENT" | wc -l) lines"
               echo "log-file=$LOG_CONTENT" >> "$GITHUB_OUTPUT"
           env:

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -62,9 +62,9 @@ runs:
               repo="${BASH_REMATCH[2]}"
               run_id="${BASH_REMATCH[3]}"
 
-              echo "owner=$owner" >> $GITHUB_OUTPUT
-              echo "repo=$repo" >> $GITHUB_OUTPUT
-              echo "run_id=$run_id" >> $GITHUB_OUTPUT
+              echo "owner=$owner" >> "$GITHUB_OUTPUT"
+              echo "repo=$repo" >> "$GITHUB_OUTPUT"
+              echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
               echo "Parsed URL:"
               echo "  Owner: $owner"
@@ -110,12 +110,13 @@ runs:
               # Both CR and LF: the value is written to the line-oriented $GITHUB_OUTPUT, and
               # this is log text from an arbitrary workflow run, so it is not trusted input.
               LOG_CONTENT="$(tr -d '\r\n' < logs/trimmed_50kb.log)"
-              echo "Downsized log file size: $(echo "$LOG_CONTENT" | wc -l) lines"
+              echo "Downsized log content: ${#LOG_CONTENT} characters"
               echo "log-file=$LOG_CONTENT" >> "$GITHUB_OUTPUT"
           env:
-              # These derive from the caller-supplied URL. The parse step constrains them to
-              # GitHub's naming rules, and passing them through env keeps them out of the
-              # script text regardless — the two together, not either alone.
+              # These derive from the caller-supplied URL. The parse step constrains them to a
+              # charset with no newline, whitespace or shell metacharacter, and passing them
+              # through env keeps them out of the script text regardless — the two together,
+              # not either alone.
               GH_REPO: ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }}
               GH_TOKEN: ${{ inputs.gh_token }}
               RUN_ID: ${{ steps.parse-url.outputs.run_id }}

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -83,13 +83,13 @@ runs:
           id: fetch-logs
           run: |
               # Download logs using GitHub CLI
-              echo "Fetching logs for run ${{ steps.parse-url.outputs.run_id }} from ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }}"
+              echo "Fetching logs for run ${RUN_ID} from ${GH_REPO}"
 
               # Create logs directory
               mkdir -p logs
 
-              gh run view ${{ steps.parse-url.outputs.run_id }} \
-                --repo ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }} \
+              gh run view "${RUN_ID}" \
+                --repo "${GH_REPO}" \
                 --log-failed > logs/failed.log
 
               echo "removing timestamps and downsizing logs"
@@ -106,7 +106,11 @@ runs:
               echo "Downsized log file size: $(echo "$LOG_CONTENT" | wc -l) lines"
               echo "log-file=$LOG_CONTENT" >> "$GITHUB_OUTPUT"
           env:
+              # owner and repo are captured from the URL with `[^/]+`, so they can carry shell
+              # metacharacters. The step above already routes them through env; this one did not.
+              GH_REPO: ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }}
               GH_TOKEN: ${{ inputs.gh_token }}
+              RUN_ID: ${{ steps.parse-url.outputs.run_id }}
 
         - name: Analyze Logs with AI
           id: analyze

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -110,8 +110,9 @@ runs:
               echo "Downsized log file size: $(echo "$LOG_CONTENT" | wc -l) lines"
               echo "log-file=$LOG_CONTENT" >> "$GITHUB_OUTPUT"
           env:
-              # owner and repo are captured from the URL with `[^/]+`, so they can carry shell
-              # metacharacters. The step above already routes them through env; this one did not.
+              # These derive from the caller-supplied URL. The parse step constrains them to
+              # GitHub's naming rules, and passing them through env keeps them out of the
+              # script text regardless — the two together, not either alone.
               GH_REPO: ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }}
               GH_TOKEN: ${{ inputs.gh_token }}
               RUN_ID: ${{ steps.parse-url.outputs.run_id }}

--- a/.github/actions/gha-failure-log-analyzer/action.yml
+++ b/.github/actions/gha-failure-log-analyzer/action.yml
@@ -47,7 +47,11 @@ runs:
               # Expected format: https://github.com/owner/repo/actions/runs/run_id
               url="${INPUTS_RUN_URL}"
 
-              if [[ ! "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/actions/runs/([0-9]+) ]]; then
+              # owner and repo are constrained to GitHub's own naming rules rather than "[^/]+".
+              # They are written to $GITHUB_OUTPUT and later used as command arguments, so a
+              # newline would define extra step outputs and a metacharacter would travel with
+              # them. Validating the capture is simpler than sanitising every consumer.
+              if [[ ! "$url" =~ ^https://github\.com/([A-Za-z0-9-]+)/([A-Za-z0-9._-]+)/actions/runs/([0-9]+) ]]; then
                 echo "Error: Invalid GitHub Actions URL format"
                 echo "Expected format: https://github.com/owner/repo/actions/runs/run_id"
                 exit 1


### PR DESCRIPTION
Follow-up to camunda/infraex-common-config#551 (comment), which merged before it was
addressed.

## What #551 missed

#551 moved caller inputs out of `run:` bodies into `env:`, so GitHub no longer substitutes
them into the script before the shell parses it. It only closed the direct path. A step can
echo an input straight back out, and the resulting `steps.*.outputs.*` was still expanded
into later scripts — putting the value right back in front of the parser.

### `asdf-install-tooling`

`detect-arch` returns `inputs.arch` verbatim whenever it is not `"auto"`:

```bash
else
  ARCH="${INPUTS_ARCH}"
fi
echo "arch=$ARCH" | tee -a "$GITHUB_OUTPUT"
```

`steps.detect-arch.outputs.arch` was then expanded into two `run:` bodies — the cache key
and `FILE_NAME`. So routing `inputs.arch` through `env:` bought nothing: the value arrived
at the shell as source either way.

Now passed as `DETECTED_ARCH`. `runner.os` goes with it as the built-in `RUNNER_OS` — not
caller-controlled, it simply has no reason to be an expression.

### `gha-failure-log-analyzer`

Found by sweeping for the same pattern rather than reported. `owner` and `repo` are
captured from the URL with `[^/]+`, which admits `;`, `$(...)`, backticks and spaces:

```bash
if [[ ! "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/actions/runs/([0-9]+) ]]; then
```

and were expanded **unquoted** into a command:

```bash
gh run view ${{ steps.parse-url.outputs.run_id }} \
  --repo ${{ steps.parse-url.outputs.owner }}/${{ steps.parse-url.outputs.repo }} \
```

The step immediately above already routes the same two values through `GH_REPO`, so this
change follows a pattern the file had established rather than inventing one.

## Reachability

Neither is reachable from the current callers, and I would rather say that than overstate
the finding:

- `lint-global.yml` never sets `arch`, so it stays `"auto"` and takes the `uname -m` branch.
- `run_url` is built from `github.server_url` / `github.repository` / `github.run_id` in
  `report-failure-on-slack`, none of them attacker-controlled.

Both are public reusable actions consumed outside this repository, and
`gha-failure-log-analyzer` is additionally `workflow_dispatch`-triggered, so the input can
come from anyone with write access. The fix costs nothing either way.

## Worth noting for the zizmor rollout

**zizmor does not flag either of these, at any severity.** It treats `steps.*.outputs.*` as
non-controllable and does not trace the value back to the input it came from. Both files
are clean under `--min-severity=high` before and after this change.

That is a useful calibration for the hook added in #551: it catches the direct
`${{ inputs.* }}` in `run:` pattern, not values laundered through a step output. Relevant to
whoever picks up the fleet-wide rollout.

## What the review rounds added

The first commit only closed the shell-parser path. Review pushed back five times, and each
push was right about something:

**Round 2 — `$GITHUB_OUTPUT` is also a sink.** `arch` is written to the output file *and*
read back into the `cache_key=` line, so a newline in `inputs.arch` defines extra step
outputs regardless of how the value reaches the shell. I had written this off as out of
scope in this description, which was inconsistent with the change itself. Fixed at the
source instead of at each sink: `arch` must now match `^[A-Za-z0-9_-]+$` when supplied, and
the URL capture groups were tightened from `[^/]+`.

**Round 3 — the comments had gone stale.** Tightening the capture groups made the comments
describing them wrong, in the part of the file that exists to explain why the control is
there.

**Round 4 — one input at a time is the wrong pace.** `inputs.version` reaches the same
output line. Rather than patch it and wait, I swept every input of the action:

| input | reaches | action |
|---|---|---|
| `version` | `$GITHUB_OUTPUT` (`cache_key`), download URL | validated `^[A-Za-z0-9._-]+$` |
| `os` | download URL | allowlisted `^(linux\|darwin)$` |
| `arch` | `$GITHUB_OUTPUT` (`cache_key`), download URL | validated |
| `cache` | only compared in an `if:`, never a shell | nothing needed |
| `tool_versions_files` | only ever a quoted path in `[ -f … ]`, `sha256sum`, `dirname` | **left alone deliberately** |

`os` is an allowlist rather than a charset because the input documents itself as "linux or
darwin" and the release assets only exist for those two.

**Round 5 — CR as well as LF, and a comment overclaiming.** The log content written to
`$GITHUB_OUTPUT` stripped LF but not CR. And the comment above the URL capture claimed
"GitHub's own naming rules", which `[A-Za-z0-9-]+` is not — it still admits a leading
hyphen. Reworded to state what the regex guarantees: no newline, no whitespace, no shell
metacharacter.

**Round 6 — consistency.** Fixing one of a pair of comments left the other contradicting
it. Plus `$GITHUB_OUTPUT` unquoted in three writes where the rest of the file quotes it,
and a `wc -l` that always printed 1 because every newline had just been stripped from the
value it measured.

Three of those six rounds were comments promising more than the code delivered. In a file
whose comments exist to justify a security control, that is worse than no comment, because
the next person edits against it.

## Verification

- `pre-commit run --all-files` → green, `actionlint` and `zizmor` included.
- Swept both files afterwards for any remaining `${{ … }}` inside a `run:` body: none left.
- Validation exercised against real values — `amd64`, `arm64`, `386`, `ppc64le`, `x86_64`;
  `v0.20.0`, `0.18.1`, `v1.2.3-rc.1`; `linux`, `darwin`; repository names carrying dots,
  underscores and hyphens — all accepted. And against newline, `;`, `$(...)` and space
  payloads — all rejected.
- **No CI ran.** Actions is disabled repository-wide (`actions/permissions` → `enabled:
  false`), as it has been since 2026-08-06. Everything above is local.
