### PR TITLE
fix(lint-global): inline pre-commit instead of pre-commit/action [ready]

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -95,17 +95,38 @@ jobs:
             - name: Install asdf tools
               uses: camunda/infraex-common-config/.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
 
-            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-              id: pre_commit_check_first_run
+            # pre-commit/action is deliberately not used: it resolves `actions/cache@v4`, an
+            # unpinned reference. GitHub evaluates "Require actions to be pinned to a full-length
+            # commit SHA" over the entire dependency tree at Set up job, so in a repository with
+            # that setting on, every run reaching this workflow is refused before any step runs
+            # and the caller has no way to work around it.
+            #
+            # Inlining the action also drops the `pip install pre-commit` it performs, which
+            # silently installed the latest release over the version the repository pins in
+            # .tool-versions.
+            - name: Check pre-commit is available
+              run: |
+                  set -euo pipefail
+                  if ! command -v pre-commit >/dev/null 2>&1; then
+                    echo "::error::pre-commit is not installed. Add it to the repository's .tool-versions, the asdf step above installs it from there."
+                    exit 1
+                  fi
+                  pre-commit --version
+
+            - name: Cache pre-commit hook environments
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
-                  extra_args: --all-files --verbose
+                  path: ~/.cache/pre-commit
+                  key: pre-commit-1|${{ runner.os }}|${{ hashFiles('.pre-commit-config.yaml', '.tool-versions') }}
+
+            - name: Run pre-commit
+              id: pre_commit_check_first_run
+              run: pre-commit run --show-diff-on-failure --color=always --all-files --verbose
 
             - name: Rerun pre-commit to autofix files if pre-commit failed
-              uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-              if: ${{ !cancelled() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success' }}
               id: pre_commit_check_second_run
-              with:
-                  extra_args: --all-files --verbose
+              if: ${{ !cancelled() && steps.mode.outputs.autofix_pr == 'true' && steps.pre_commit_check_first_run.outcome != 'success' }}
+              run: pre-commit run --show-diff-on-failure --color=always --all-files --verbose
 
             # The first pre-commit run checks the files. If the second run passes, pre-commit
             # applied automatic fixes; if it still fails, pre-commit could not resolve the issue


### PR DESCRIPTION
## Problem

`lint-global.yml` calls `pre-commit/action@2c7b3805` (v3.0.1), which internally resolves `actions/cache@v4` — an unpinned reference we do not control.

GitHub evaluates **Settings → Actions → General → Require actions to be pinned to a full-length commit SHA** over the *entire* dependency tree, at `Set up job`, before any step executes. So in a repository with that setting on, every run of this reusable workflow is refused outright:

```
##[error]The action actions/cache@v4 is not allowed in camunda/infraex-terraform
because all actions must be pinned to a full-length commit SHA.
```

Pinning the call site does not help, and upstream `pre-commit/action` is unlikely to pin quickly. `camunda/infraex-terraform` has the setting enabled and currently cannot lint at all.

## Change

The action is four steps; they are inlined:

| `pre-commit/action` does | Replaced by |
| --- | --- |
| `pip install pre-commit` | nothing — `pre-commit` already comes from the caller's `.tool-versions` via the asdf step right above |
| `actions/cache@v4` on `~/.cache/pre-commit` | `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0` |
| `pre-commit run --show-diff-on-failure --color=always <extra_args>` | same command, `--all-files --verbose` |

A guard step fails with an actionable message if `pre-commit` is missing from the toolchain.

Step ids, `outcome` semantics and the auto-fix flow are unchanged: a failing `run:` step reports `outcome: failure` exactly like the failing composite action did, and the downstream steps keep their `!cancelled()` conditions.

## Behaviour change worth knowing

`pre-commit/action` ran `pip install pre-commit`, i.e. **the latest release**, over whatever the repository pinned in `.tool-versions`. The version that actually linted was not the one declared. It now is. All current callers pin `pre-commit` in `.tool-versions` (`4.6.1`, `4.5.1` for `c8-multi-region`), so this only means the declared version is finally the one used — but a hook that misbehaved on an older pre-commit will now surface.

## Cache key

`pre-commit/action` keyed on `${{ env.pythonLocation }}`, which is set by `actions/setup-python` and is empty here since Python comes from asdf. The key is `runner.os` plus a hash of `.pre-commit-config.yaml` and `.tool-versions`, so a toolchain bump invalidates it.

## Related

* `camunda/infra-global-github-actions#779` — same problem in `generate-github-app-token-from-vault-secrets`, which this workflow's `autofix-apply` job depends on. Both are needed for a caller with the policy on to go green.
* `camunda/infra-global-github-actions#778` — `actionlint` action, same theme.