### PR TITLE
chore(deps): bump infra-global-github-actions to the SHA-pinned revision [ready]

### DIFF
--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -77,7 +77,7 @@ runs:
           # step and the analyzer trigger step, so gating it on
           # disable_silence_check leaves the trigger step without a token
           # when the silence check is disabled.
-          uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@472b20a51fb5c7c9ff991ed6177769eab487eb34 # main
+          uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
           with:
               github-app-id-vault-key: GITHUB_APP_ID
               github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -235,7 +235,7 @@ jobs:
               id: generate-github-token
               # Only run for the next step
               if: ${{ env.should_run == 'true' && env.AWS_REGION == 'eu-north-1' }}
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@472b20a51fb5c7c9ff991ed6177769eab487eb34 # main
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   github-app-id-vault-key: GITHUB_APP_ID
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common

--- a/.github/workflows/gha-failure-log-analyzer.yml
+++ b/.github/workflows/gha-failure-log-analyzer.yml
@@ -31,7 +31,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - name: Generate token for GitHub
               id: generate-github-token
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@472b20a51fb5c7c9ff991ed6177769eab487eb34 # main
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   github-app-id-vault-key: GITHUB_APP_ID
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -246,7 +246,7 @@ jobs:
             # PATH shim or BASH_ENV able to intercept it.
             - name: Generate token for GitHub
               id: generate-github-token
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@472b20a51fb5c7c9ff991ed6177769eab487eb34 # main
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   github-app-id-vault-key: GITHUB_APP_ID
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common


### PR DESCRIPTION
## Why

`472b20a` referenced `hashicorp/vault-action@v4.0.0` and `actions/create-github-app-token@v3` by tag. GitHub evaluates **Require actions to be pinned to a full-length commit SHA** over the whole dependency tree at `Set up job`, so in a caller with that setting on, every job resolving `generate-github-app-token-from-vault-secrets` was refused before any step ran:

```
##[error]The actions hashicorp/vault-action@v4.0.0 and actions/create-github-app-token@v3
are not allowed in camunda/infraex-terraform because all actions must be pinned to a
full-length commit SHA.
```

`camunda/infra-global-github-actions#779` pinned them and is merged; this picks up that revision.

## Change

`472b20a51fb5c7c9ff991ed6177769eab487eb34` → `14f6353d2b18d592c390f65c99f75e00c6915234` in the four places it is referenced:

* `.github/actions/report-failure-on-slack/action.yml` — the one consumers hit hardest: it takes out `terraform-drift-detection` and `certificate-renewal` in `camunda/infraex-terraform`, the latter being a scheduled Let's Encrypt renewal.
* `.github/workflows/lint-global.yml` (`autofix-apply` job)
* `.github/workflows/aws_nightly_cleanup.yml`
* `.github/workflows/gha-failure-log-analyzer.yml`

Diff between the two revisions is limited to `#779` plus what was already on `main`; no input or output of the composite action changed.

## Validation

`pre-commit run` on the changed files passes (actionlint, zizmor, yamlfmt). This repository still has Actions disabled since INC-7027, so no workflow run can confirm it here; the end-to-end proof comes from `camunda/infraex-terraform`, which has both Actions and the SHA pinning policy on.

## Related

* #557 — removes `pre-commit/action` (unpinned `actions/cache@v4`) from `lint-global.yml`, the other half of what a caller with the policy on needs.