### PR TITLE
fix(renovate): unfreeze maintenance branches, drop the hardcoded base branch, validate the preset

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -123,6 +123,34 @@
       enabled: true,
     },
     {
+      // `separateMinorPatch` defaults to false, so Renovate only builds a `major`
+      // and a `non-major` bucket. The `non-major` bucket always aims at the highest
+      // non-major release, so once upstream ships a minor the whole bucket is typed
+      // `minor` and the "Only patch updates" rule above kills it. The patch releases
+      // in between then become unreachable and the dependency freezes on the branch
+      // for good. Splitting the bucket keeps the patch lane open.
+      description: 'Keep patch updates reachable on maintenance branches once a newer minor exists.',
+      matchBaseBranches: [
+        '/^stable\\/8\\..*/',
+      ],
+      separateMinorPatch: true,
+    },
+    {
+      // These two repositories only provide the CI toolchain (reusable workflows,
+      // composite actions, pre-commit hooks). They ship nothing to the reference
+      // architecture a maintenance branch documents, so freezing them buys no
+      // stability and only leaves the branches running stale automation.
+      description: 'Track our own CI tooling on all update types on maintenance branches.',
+      matchPackageNames: [
+        'camunda/infraex-common-config',
+        'camunda/infra-global-github-actions',
+      ],
+      matchBaseBranches: [
+        '/^stable\\/8\\..*/',
+      ],
+      enabled: true,
+    },
+    {
       groupName: 'minor-grouped',
       matchUpdateTypes: [
         'minor',


### PR DESCRIPTION
Three defects in the shared Renovate config, one of which is why they went unnoticed.

## 1. Dependencies freeze on `stable/8.x`

They stop being updated altogether after a while, instead of being kept on their patch line as intended.

`separateMinorPatch` is left at its default (`false`), so with `separateMajorMinor: true` Renovate only builds two buckets: `major` and `non-major`. The `non-major` bucket always targets the **highest** non-major release.

For a dependency pinned at `1.3.8` when `1.3.9`, `1.8.0` and `2.0.1` exist:

| bucket | target | updateType | outcome |
|---|---|---|---|
| `major` | `2.0.1` | `major` | disabled by *Only patch updates for our maintenance branches* |
| `non-major` | `1.8.0` | `minor` | disabled by the same rule |

There is no `patch` bucket, so `1.3.8 -> 1.3.9` is never offered. The dependency is frozen for good the moment upstream publishes any minor. The rule was written to let patches through, but it can only ever see an update type that it also blocks.

Observable on `camunda/camunda-deployment-references`: `camunda/infraex-common-config` sits at `1.3.8`/`1.4.8`/`1.7.0` on `stable/8.7` and never appears in the `patch-grouped` PRs for that branch, while `stable/8.6` stopped at `1.3.9`, the last patch published before `1.4.0` shipped. The mixed values on a single branch come from backports, not from Renovate.

**Fix:** `separateMinorPatch: true` scoped to `matchBaseBranches: /^stable\/8\..*/`, so a real `patch` bucket exists and the *Only patch updates* rule finally has something to let through. Both `matchBaseBranches` and `separateMinorPatch` are resolved before lookup, so the scoping is effective.

Plus an exemption for `camunda/infraex-common-config` and `camunda/infra-global-github-actions`. These ship only CI plumbing (reusable workflows, composite actions, pre-commit hooks) and nothing belonging to the reference architecture a maintenance branch documents, so freezing them buys no stability and only leaves those branches running stale automation. Same shape and placement as the existing `camunda-platform` exemption, which is already proven to work.

## 2. `baseBranchPatterns` hardcoded `main`

A preset cannot know its consumers' default branch name. Any repository not using `main` silently ended up with no base branch, and every consumer had to override the key regardless.

It cannot simply be deleted: Renovate rejects `matchBaseBranches` in a config that configures no base branch (`packageRules[n]: You must configure baseBranchPatterns in order to use them inside matchBaseBranches`), and this preset uses `matchBaseBranches`.

**Fix:** `$default`, which Renovate resolves to the consuming repository's default branch (`lib/workers/repository/process/index.ts`).

## 3. The preset is never validated

`default.json5` falls outside the `renovate-config-validator` hook file pattern, so the file every consumer repository extends was the only Renovate config in this repo that CI never checked.

The CLI also treats any filename handed to it as **self-hosted global** config unless `--no-global` is passed, so even `.github/renovate.json5` was validated under the wrong ruleset and accepted global-only options.

**Fix:** extend `files` with `^default\.json5$` (upstream alternative kept verbatim) and add `--no-global`.

Before / after, same repository:

```
# before
renovate-config-validator............................(no files to check)Skipped

# after
INFO: Validating .github/renovate.json5 as repo config
INFO: Validating default.json5 as repo config
INFO: Config validated successfully against 2 file(s)
```

Negative test, injecting a global-only option into `default.json5`, which the previous setup accepted silently:

```
WARN: Found errors in configuration
      "message": "The \"binarySource\" option is a global option reserved only for
                  Renovate's global configuration and cannot be configured within a
                  repository's config file."
```

## Expected effect

Maintenance branches pick up the patches they have been missing. This lands inside the existing `patch-grouped` branch, so it grows the current per-branch PR rather than creating a burst of new ones. Existing schedules are untouched: patches on Sundays, majors on Friday nights.

## Validation

`renovate-config-validator --strict --no-global` passes on both config files, with the pinned hook version (43.288.0) and with current Renovate (44.24.1).