### PR TITLE
fix(renovate): drop the hardcoded base branch and actually validate the preset

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,36 +10,3 @@ jobs:
     lint:
         uses: ./.github/workflows/lint-global.yml
         secrets: inherit
-
-    pre-commit-renovatejsonfile:
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            # Required for pre-commit to work with Python referenced in .tool-versions for Ubuntu >= 24.04
-            - name: Install SQLite dependency
-              run: sudo apt-get install -y libsqlite3-dev
-
-            - name: Install asdf tools
-              uses: ./.github/actions/asdf-install-tooling
-
-            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-              name: Validate renovate5.json
-              with:
-                  extra_args: --all-files --verbose
-
-            - name: Prepare for pre-commit
-              run: |
-                  cp default.json5 .github/renovate.json5  # renovate-config-validator hook can only validate files that are called renovate.json5
-                  git add .github/renovate.json5
-
-            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-              name: Validate default5.json
-              with:
-                  extra_args: --all-files --verbose
-
-            - name: Revert default.json5 changes
-              run: |
-                  git restore --staged .github/renovate.json5
-                  git restore .github/renovate.json5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,14 @@ repos:
       rev: 43.288.0
       hooks:
           - id: renovate-config-validator
-            args: [--strict]
+            # --no-global is required: when the CLI is handed filenames it defaults to
+            # validating them as self-hosted global config, which silently accepts
+            # global-only options that a repo or preset must never carry.
+            args: [--strict, --no-global]
+            # The upstream pattern only matches renovate/renovaterc filenames, so
+            # default.json5 -- the preset every consumer repository extends -- was
+            # never validated. Keep the upstream alternative verbatim and add ours.
+            files: (^|/).?renovate(?:rc)?(?:\.json5?)?$|^default\.json5$
             # TODO : revert this when https://github.com/renovatebot/pre-commit-hooks/issues/2460 is fixed
             language_version: lts
 

--- a/default.json5
+++ b/default.json5
@@ -10,8 +10,12 @@
     'helpers:pinGitHubActionDigests',
     ':pinDevDependencies',
   ],
+  // Declared only because Renovate refuses `matchBaseBranches` in a config that
+  // configures no base branch. `$default` resolves to whatever the consuming
+  // repository uses as its default branch; hardcoding 'main' here silently broke
+  // any repository not named that way, and every consumer had to override it.
   baseBranchPatterns: [
-    'main',
+    '$default',
   ],
   ignorePaths: [], // overwrites default to track also test paths
   platformAutomerge: false, // Automerge cannot be applied due to branch security settings. Explicit approval from a maintainer is required, so we do not use or configure automerge in our repositories.


### PR DESCRIPTION
Follow-up to #560, which covered the maintenance branch freeze. Two remaining defects in the same area, one of which is why they all went unnoticed, plus the CI job that existed to work around one of them.

## 1. `baseBranchPatterns` hardcodes `main`

A preset cannot know its consumers' default branch name. Any repository not using `main` silently ends up with no base branch at all, and every consumer has to override the key regardless.

It cannot simply be deleted. Renovate rejects `matchBaseBranches` in a config that configures no base branch, and this preset uses `matchBaseBranches` in four rules:

```
WARN: Found errors in configuration
      packageRules[5]: You must configure baseBranchPatterns in order to use them inside matchBaseBranches.
      packageRules[6]: ...
      packageRules[7]: ...
      packageRules[8]: ...
```

**Fix:** `$default`, which Renovate resolves to the consuming repository's default branch (`lib/workers/repository/process/index.ts`, `baseBranchPatterns "$default" matches "<defaultBranch>"`). The comment records why the key has to stay at all.

## 2. The preset is never validated

`default.json5` falls outside the `renovate-config-validator` hook file pattern (`(^|/).?renovate(?:rc)?(?:\.json5?)?$`), so the file every consumer repository extends is the only Renovate config here that CI never checks.

Worse, the CLI treats any filename handed to it as **self-hosted global** config unless `--no-global` is passed. Since pre-commit always passes filenames, even `.github/renovate.json5` was validated under the wrong ruleset, which accepts global-only options that a repo config or a preset must never carry.

**Fix:** extend `files` with `^default\.json5$` (upstream alternative kept verbatim) and add `--no-global`.

Before / after, same repository, same command:

```
# before
renovate-config-validator............................(no files to check)Skipped

# after
INFO: Validating .github/renovate.json5 as repo config
INFO: Validating default.json5 as repo config
INFO: Config validated successfully against 2 file(s)
```

Negative test, injecting a global-only option into `default.json5`, which the previous setup accepted in silence:

```
WARN: Found errors in configuration
      "message": "The \"binarySource\" option is a global option reserved only for
                  Renovate's global configuration and cannot be configured within a
                  repository's config file."
```

## 3. `lint.yml`: the `pre-commit-renovatejsonfile` job is removed

That job existed only to reach `default.json5` despite the file pattern above. Its own comment says so:

```yaml
cp default.json5 .github/renovate.json5  # renovate-config-validator hook can only validate files that are called renovate.json5
```

It copied the preset over `.github/renovate.json5`, ran the **entire** hook suite a second time, then reverted. With the pattern fixed the copy is pointless, and `lint-global` already runs `pre-commit run --all-files`.

It was also the last caller of `pre-commit/action`, the dependency #557 removed from `lint-global.yml` but missed here. It is why this PR was red:

```
The action actions/cache@v4 is not allowed in camunda/infraex-common-config
because all actions must be pinned to a full-length commit SHA.
```

The job failed at **Set up job**, before any step ran. This is pre-existing, not introduced here: `lint.yml` last ran on 2026-08-06, before that requirement was enforced, so this PR is simply the first run to hit it.

## Validation

`pre-commit run --all-files` passes locally, `renovate-config-validator` included, and it now covers `default.json5`:

```
Update GitHub Action READMEs.............................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
Lint GitHub Actions workflow files.......................................Passed
renovate-config-validator................................................Passed
Format YAML files........................................................Passed
zizmor...................................................................Passed
```

`renovate-config-validator --strict --no-global` passes on both config files, with the pinned hook version (43.288.0) and with current Renovate (44.24.1).