### PR TITLE
ci: make the pinning policy explicit and re-pin infra-global-github-actions

### DIFF
--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -77,7 +77,7 @@ runs:
           # step and the analyzer trigger step, so gating it on
           # disable_silence_check leaves the trigger step without a token
           # when the silence check is disabled.
-          uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+          uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
           with:
               github-app-id-vault-key: GITHUB_APP_ID
               github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common

--- a/.github/workflows/aws_nightly_cleanup.yml
+++ b/.github/workflows/aws_nightly_cleanup.yml
@@ -235,7 +235,7 @@ jobs:
               id: generate-github-token
               # Only run for the next step
               if: ${{ env.should_run == 'true' && env.AWS_REGION == 'eu-north-1' }}
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   github-app-id-vault-key: GITHUB_APP_ID
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common

--- a/.github/workflows/gha-failure-log-analyzer.yml
+++ b/.github/workflows/gha-failure-log-analyzer.yml
@@ -31,7 +31,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - name: Generate token for GitHub
               id: generate-github-token
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   github-app-id-vault-key: GITHUB_APP_ID
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common

--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -267,7 +267,7 @@ jobs:
             # PATH shim or BASH_ENV able to intercept it.
             - name: Generate token for GitHub
               id: generate-github-token
-              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   github-app-id-vault-key: GITHUB_APP_ID
                   github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,47 @@
+---
+# =============================================================================
+# zizmor.yml — GitHub Actions supply-chain policy for infraex-common-config
+#
+# Consumed by the `zizmor` pre-commit hook (see .pre-commit-config.yaml), which
+# runs locally on `pre-commit run -a` and in CI through lint-global.
+#
+# This repository is public and its reusable workflows and composite actions are
+# consumed by other repositories, so an unpinned action reference here is not
+# just our own exposure: it is inherited by every caller.
+#
+# Mirrors the policy adopted in camunda/infra-global-github-actions#781.
+#
+# Docs: https://docs.zizmor.sh/configuration/
+# =============================================================================
+
+rules:
+    unpinned-uses:
+        config:
+            # `policies` maps action-owner globs to a pinning level.
+            #
+            #   any       — no constraint; any ref (SHA, tag, branch) is accepted.
+            #   ref-pin   — must carry an explicit ref, symbolic (tag/branch) or SHA.
+            #   hash-pin  — must be a 40-character commit SHA. Tags and branches fail.
+            #
+            # Local references (`uses: ./.github/actions/...`) are same-repo and are
+            # skipped by this audit entirely, so they need no policy entry.
+            policies:
+                # Everything is hash-pinned, with no namespace exemption, including
+                # `actions/*` and this organisation's own repositories.
+                #
+                # The binding constraint is not our own threat model but GitHub's
+                # `Require actions to be pinned to a full-length commit SHA` setting,
+                # which several consumers already enforce and which grants no
+                # exemption:
+                #
+                #   "all actions must be pinned to a full-length commit SHA to be
+                #    used. This includes actions from your organization and actions
+                #    authored by GitHub. Reusable workflows can still be referenced
+                #    by tag."
+                #   -- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
+                #
+                # It is evaluated over the whole dependency tree at `Set up job`, so
+                # a tag left inside a composite action here refuses the caller's job
+                # before any step runs, and the caller cannot work around it by
+                # picking a different revision of this repository.
+                '*': hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,5 +49,10 @@ repos:
           # Without GH_TOKEN zizmor runs offline, which skips known-vulnerable-actions,
           # impostor-commit, ref-confusion, ref-version-mismatch and stale-action-refs.
           # None of those currently report anything at `high`.
+          #
+          # --config makes the pinning policy explicit in .github/zizmor.yml rather than
+          # leaving it to zizmor's defaults. The repository is already fully SHA-pinned,
+          # so this changes no finding today; it stops a future default change from
+          # silently dropping `unpinned-uses` below the `high` threshold above.
           - id: zizmor
-            args: [--no-progress, --min-severity=high]
+            args: [--no-progress, --min-severity=high, --config=.github/zizmor.yml]


### PR DESCRIPTION
Applies the policy from camunda/infra-global-github-actions#781 here. **The audit came back cleaner than expected, so this is smaller than that PR** — most of the work was already done.

## What was already true

- **Zero unpinned action references.** Every `uses:` in this repository, workflows and composite actions alike, is already a 40-character SHA, including `actions/*` and the `camunda/*` self-references.
- **The gate already bites.** `zizmor` runs in `.pre-commit-config.yaml` and locally rejects a reverted pin today, before this PR:

  ```
  actions/* on tag      -> zizmor ... Failed
  camunda/* on branch   -> zizmor ... Failed
  composite action.yml  -> zizmor ... Failed
  ```

So nothing here is broken. There is no consumer to unblock.

## What this changes

**1. `.github/zizmor.yml` — the policy is written down**

Enforcement currently relies on two implicit things: zizmor's default `unpinned-uses` behaviour, and the fact that it happens to classify these findings as `high`, which is the threshold the hook runs with (`--min-severity=high`). Verified today:

```
188 findings (67 ignored, 120 suppressed): 0 informational, 0 low, 0 medium, 1 high
```

That `1 high` is the injected violation. If a future zizmor release reclassified `unpinned-uses` as `medium`, the threshold would silently stop catching it and the repository would drift back to tags with a green gate. An explicit `"*": hash-pin` policy removes that coupling.

No namespace is exempt, `actions/*` and `camunda/*` included. The binding constraint is not our own threat model but GitHub's **Require actions to be pinned to a full-length commit SHA**, which several consumers already enforce and which grants no exemption:

> This includes actions from your organization and actions authored by GitHub. Reusable workflows can still be referenced by tag.

It is evaluated over the whole dependency tree at `Set up job`, so a tag inside a composite action here refuses the **caller's** job, and the caller cannot work around it by picking a different revision of this repository.

Unlike infra-global-github-actions, this repository has no `@main` self-reference contract to preserve, so there is no exemption to carve out and no `KNOWN GAP` to record.

**2. `infra-global-github-actions` `14f6353d` -> `3ec04ae6`** (4 references)

`3ec04ae6` is the merge of camunda/infra-global-github-actions#781. Checked, and stated plainly because it affects how this should be read: the consumed action's tree carries **0 unpinned references at both revisions**, so this is alignment with the rest of the fleet, not a fix. `14f6353d` was already the revision where that specific action was pinned.

## Verification

- `pre-commit run --all-files` green, `zizmor` and `actionlint` included.
- Negative tests rerun with the explicit config: `actions/*` on a tag, `camunda/*` on a branch, and an unpinned ref inside a composite `action.yml` all `Failed`.
- Diff is 6 files, 55 insertions, and 45 of those insertions are the new policy file with its rationale.