### PR TITLE
ci(lint-global): assert the pinned pre-commit and key the cache on the interpreter

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -104,20 +104,45 @@ jobs:
             # Inlining the action also drops the `pip install pre-commit` it performs, which
             # silently installed the latest release over the version the repository pins in
             # .tool-versions.
-            - name: Check pre-commit is available
+            - name: Check pre-commit matches the caller's .tool-versions
+              id: toolchain
               run: |
                   set -euo pipefail
-                  if ! command -v pre-commit >/dev/null 2>&1; then
-                    echo "::error::pre-commit is not installed. Add it to the repository's .tool-versions, the asdf step above installs it from there."
+
+                  expected="$(awk '$1 == "pre-commit" { print $2; exit }' .tool-versions 2>/dev/null || true)"
+                  if [ -z "$expected" ]; then
+                    echo "::error::.tool-versions does not pin pre-commit. Add a 'pre-commit <version>' line to this repository's .tool-versions; the asdf step above installs it from there."
                     exit 1
                   fi
-                  pre-commit --version
+
+                  if ! command -v pre-commit >/dev/null 2>&1; then
+                    echo "::error::pre-commit is not installed. The asdf step above should have provided ${expected} from this repository's .tool-versions."
+                    exit 1
+                  fi
+
+                  # Not just a PATH check: a pre-commit shipped with the runner image would
+                  # satisfy `command -v` while silently running a different version from the
+                  # one the caller pins, which is the drift inlining exists to remove.
+                  actual="$(pre-commit --version | awk '{ print $2 }')"
+                  if [ "$actual" != "$expected" ]; then
+                    echo "::error::pre-commit ${actual} is on PATH but .tool-versions pins ${expected}. The asdf install did not take effect."
+                    exit 1
+                  fi
+                  echo "pre-commit ${actual} matches .tool-versions"
+
+                  # The interpreter identity has to be part of the cache key. Callers are not
+                  # required to pin python in .tool-versions -- when they do not, python comes
+                  # from the runner image and can move while .pre-commit-config.yaml and
+                  # .tool-versions both stay identical. The stale hook environments would then
+                  # be restored on an exact key hit, rebuilt against the new interpreter, and
+                  # never saved, reinstalling on every run.
+                  echo "python=$(python3 --version 2>&1 | tr ' ' '-')" | tee -a "$GITHUB_OUTPUT"
 
             - name: Cache pre-commit hook environments
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: ~/.cache/pre-commit
-                  key: pre-commit-1|${{ runner.os }}|${{ hashFiles('.pre-commit-config.yaml', '.tool-versions') }}
+                  key: pre-commit-2|${{ runner.os }}|${{ steps.toolchain.outputs.python }}|${{ hashFiles('.pre-commit-config.yaml', '.tool-versions') }}
 
             - name: Run pre-commit
               id: pre_commit_check_first_run


### PR DESCRIPTION
Both defects were found by review on the equivalent change in camunda/infra-global-github-actions#783. They apply here too, with more reach: `lint-global` runs for six repositories, not one.

To be clear about what is **not** here — `pre-commit/action` was already removed from this workflow in #557 and from `lint.yml` in #561. camunda/infra-global-github-actions#783 was porting that fix outward, not the reverse. Nothing to bring back.

## 1. The guard did not check what its own error message claimed

```bash
if ! command -v pre-commit >/dev/null 2>&1; then
  echo "::error::pre-commit is not installed. Add it to the repository's .tool-versions, ..."
```

A `pre-commit` shipped in the runner image satisfies `command -v` while running a different version from the one the caller pins — precisely the drift inlining exists to remove. The check passes, the message about `.tool-versions` is never true, and the failure surfaces later as an unexplained hook result.

Now compares:

```bash
expected="$(awk '$1 == "pre-commit" { print $2; exit }' .tool-versions)"
actual="$(pre-commit --version | awk '{ print $2 }')"
```

Fails with both versions named if they diverge, and fails separately if `.tool-versions` does not pin `pre-commit` at all — otherwise an empty `expected` would make the comparison pass vacuously.

Checked against every caller before changing a shared workflow:

| caller | `pre-commit` pinned |
|---|---|
| `camunda-deployment-references` | `4.6.1` |
| `keycloak` | `4.6.1` |
| `infraex-terraform` | `4.6.1` |
| `c8-sm-checks` | `4.6.1` |
| `team-infrastructure-experience` | `4.6.1` |
| `c8-multi-region` | `4.5.1` |

All six pass the stricter guard. No caller is broken by this.

## 2. The cache key could not see the interpreter

```
key: pre-commit-1|${{ runner.os }}|${{ hashFiles('.pre-commit-config.yaml', '.tool-versions') }}
```

Callers are **not** required to pin python in `.tool-versions`, and `c8-sm-checks` does not. There, python comes from the runner image and can move while `.pre-commit-config.yaml` and `.tool-versions` both stay byte-identical. The stale hook environments are then restored on an *exact* key hit, `pre-commit` rebuilds them against the new interpreter, and because the hit was exact the rebuild is never saved — reinstalling every hook on every run, indefinitely.

Note this is not the `pythonLocation` fix used in camunda/infra-global-github-actions#783: that workflow resolves python through `actions/setup-python`, this one gets it from `asdf`, so `env.pythonLocation` is unset here. The resolved version is captured instead:

```bash
echo "python=$(python3 --version 2>&1 | tr ' ' '-')" | tee -a "$GITHUB_OUTPUT"
```

Key prefix bumped `pre-commit-1` -> `pre-commit-2` so existing entries, written under a key that could not distinguish interpreters, are not carried over.

## Verification

- `pre-commit run --all-files` green, `actionlint`, `zizmor` and `renovate-config-validator` included.
- Guard confirmed live rather than assumed: this machine has `pre-commit 4.6.0` against the pinned `4.6.1`, and the new logic rejects it.
- Cache component resolves as expected locally: `Python-3.14.6`.

## Sequencing

Independent of #562, which touches `.github/zizmor.yml`, `.pre-commit-config.yaml` and the `infra-global-github-actions` pins. No shared lines, either can land first.
