### PR TITLE
feat(actions): add matrix-outputs-read

### DIFF
--- a/.github/actions/matrix-outputs-read/README.md
+++ b/.github/actions/matrix-outputs-read/README.md
@@ -1,0 +1,55 @@
+# Matrix outputs - read
+
+## Description
+
+Collect the per-job outputs written by a matrix step and merge them into a single
+JSON object, keyed by output name then by matrix key.
+
+Drop-in replacement for `cloudposse/github-action-matrix-outputs-read`, kept because
+that action's own `action.yml` references `dcarbone/install-jq-action@v2.1.0` and
+`actions/download-artifact@v4` without pinning them. GitHub evaluates the
+`Require actions to be pinned to a full-length commit SHA` setting over the entire
+dependency tree at `Set up job`, so a caller with that setting on has its job refused
+before any step runs, and cannot work around it by choosing a different revision.
+Upstream last released in 2024-02 and its main branch is still unpinned, so there is
+no revision to move to.
+
+Pair it with `cloudposse/github-action-matrix-outputs-write`, which is unaffected: at
+its current release it contains no `uses:` at all.
+
+The job calling this action does not need `actions/checkout`. It must not have one
+either if it can be avoided: the download below places every artifact in the working
+directory, which is then walked with `find . -maxdepth 2`, and a checkout would put
+repository files inside that search path.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `matrix-step-name` | <p>Name passed as <code>matrix-step-name</code> to the matching write step. It is also the artifact file name this action looks for.</p> | `true` | `""` |
+
+
+## Outputs
+
+| name | description |
+| --- | --- |
+| `result` | <p>Merged JSON object. For a matrix writing <code>{"kube": "..."}</code> under keys <code>c1</code> and <code>c2</code>, the result is <code>{"kube": {"c1": "...", "c2": "..."}}</code>.</p> |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/infraex-common-config/.github/actions/matrix-outputs-read@main
+  with:
+    matrix-step-name:
+    # Name passed as `matrix-step-name` to the matching write step. It is also the
+    # artifact file name this action looks for.
+    #
+    # Required: true
+    # Default: ""
+```

--- a/.github/actions/matrix-outputs-read/action.yml
+++ b/.github/actions/matrix-outputs-read/action.yml
@@ -1,0 +1,70 @@
+---
+name: Matrix outputs - read
+description: |
+    Collect the per-job outputs written by a matrix step and merge them into a single
+    JSON object, keyed by output name then by matrix key.
+
+    Drop-in replacement for `cloudposse/github-action-matrix-outputs-read`, kept because
+    that action's own `action.yml` references `dcarbone/install-jq-action@v2.1.0` and
+    `actions/download-artifact@v4` without pinning them. GitHub evaluates the
+    `Require actions to be pinned to a full-length commit SHA` setting over the entire
+    dependency tree at `Set up job`, so a caller with that setting on has its job refused
+    before any step runs, and cannot work around it by choosing a different revision.
+    Upstream last released in 2024-02 and its main branch is still unpinned, so there is
+    no revision to move to.
+
+    Pair it with `cloudposse/github-action-matrix-outputs-write`, which is unaffected: at
+    its current release it contains no `uses:` at all.
+
+    The job calling this action does not need `actions/checkout`. It must not have one
+    either if it can be avoided: the download below places every artifact in the working
+    directory, which is then walked with `find . -maxdepth 2`, and a checkout would put
+    repository files inside that search path.
+
+inputs:
+    matrix-step-name:
+        description: |
+            Name passed as `matrix-step-name` to the matching write step. It is also the
+            artifact file name this action looks for.
+        required: true
+
+outputs:
+    result:
+        description: |
+            Merged JSON object. For a matrix writing `{"kube": "..."}` under keys `c1` and
+            `c2`, the result is `{"kube": {"c1": "...", "c2": "..."}}`.
+        value: ${{ steps.context.outputs.result }}
+
+runs:
+    using: composite
+    steps:
+        - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+
+        # The upstream action force-installs jq 1.6 through a third-party action. That step
+        # is deliberately not reproduced: the GitHub runner images already ship jq, and the
+        # two versions were run against the same fixture and produce byte-identical output
+        # for this program. The install bought nothing and pulled in the unpinned reference
+        # this action exists to avoid.
+        - id: context
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              if ! command -v jq >/dev/null 2>&1; then
+                echo "::error::jq is not available on this runner. It ships with the GitHub-hosted images; on a self-hosted runner, install it before calling this action."
+                exit 1
+              fi
+
+              # jq program kept verbatim from the upstream action, only split over several
+              # lines for readability. Single quotes are required: $matrix_key and $item are
+              # jq variables and must not be expanded by the shell, which is what SC2016
+              # warns about and why it is disabled rather than "fixed".
+              # shellcheck disable=SC2016
+              jq_filter='map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .})))
+                | flatten
+                | reduce .[] as $item ({}; . * $item)'
+
+              result="$(find . -name "$MATRIX_STEP_NAME" -maxdepth 2 -exec cat {} \; | jq -c --slurp "$jq_filter")"
+              echo "result=${result}" | tee -a "$GITHUB_OUTPUT"
+          env:
+              MATRIX_STEP_NAME: ${{ inputs.matrix-step-name }}


### PR DESCRIPTION
Adds `matrix-outputs-read`, a pinned replacement for `cloudposse/github-action-matrix-outputs-read`.

## Why

The upstream action is pinned by SHA where it is used, but its own `action.yml` is not:

```yaml
- name: 'Setup jq'
  uses: dcarbone/install-jq-action@v2.1.0
- uses: actions/download-artifact@v4
```

GitHub evaluates **Require actions to be pinned to a full-length commit SHA** over the **whole** dependency tree at `Set up job`, so a caller with that setting on is refused before any step runs:

```
The actions dcarbone/install-jq-action@v2.1.0 and actions/download-artifact@v4
are not allowed in <repo> because all actions must be pinned to a full-length commit SHA.
```

There is nothing to bump to: upstream's last release is **1.0.0, 2024-02-28**, and its `main` is still unpinned today.

`cloudposse/github-action-matrix-outputs-write` is unaffected — at its current release it contains no `uses:` at all — so only the read half needs replacing.

## Why here rather than inlined at each call site

The first attempt inlined the three steps directly in the calling workflows: six call sites on one branch, and the same again on five maintenance branches. That is 30-odd copies of a pin that then has to be updated 30 times.

A **remote** action does not need `actions/checkout` in the calling job — GitHub fetches it the same way it fetched the cloudposse one. That was the objection to a local composite action, and it does not apply here.

It matters that no checkout is needed: `download-artifact` drops every artifact into the working directory, which is then walked with `find . -maxdepth 2`. A checkout would put repository files inside that search path.

## Differences from upstream

**The `Setup jq` step is dropped, not pinned.** It force-installed jq 1.6 through the very third-party action that pulled in the unpinned reference. The runner images already ship jq. Both versions were run against the same fixture:

```
jq 1.6    -> {"kube":{"c1":"x","c3":"z","c2":"y"},"extra":{"c1":1,"c2":2}}
jq 1.7.1  -> {"kube":{"c1":"x","c3":"z","c2":"y"},"extra":{"c1":1,"c2":2}}
```

Byte-identical, key order included. A guard reports a clear error if `jq` is ever absent, which matters for self-hosted runners.

**`matrix-step-name` is passed through the environment** rather than interpolated into the script, so a value containing shell metacharacters cannot reach the command line.

The jq program itself is unchanged.

## Verification

- `pre-commit run --all-files` green: `actionlint`, `zizmor`, `yamllint`, `yamlfmt`, README generation.
- The step logic was executed against a two-artifact fixture and writes the expected merged object to `GITHUB_OUTPUT`:
  ```
  result={"kube":{"c1":"x","c2":"y"},"extra":{"c1":1,"c2":2}}
  ```

## Follow-up

`camunda/camunda-deployment-references` #3020 and its five backports currently carry the inlined form. Once this is released they will be rewritten to call this action instead, on `main` and on each maintenance branch.
