### PR TITLE
security: split the Slack alert credentials by purpose

### DIFF
--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -71,6 +71,24 @@ outputs:
 runs:
     using: composite
     steps:
+        - name: Resolve which repositories the token needs
+          id: token-scope
+          shell: bash
+          run: |
+              set -euo pipefail
+              # The token has exactly two consumers, and between them they touch two
+              # repositories:
+              #   - the silence check reads issues on the calling repository
+              #   - the analyzer trigger dispatches a workflow in infraex-common-config
+              # Anything wider is granted for no reason.
+              caller="${GITHUB_REPOSITORY#*/}"
+              analyzer="infraex-common-config"
+              if [ "${caller}" = "${analyzer}" ]; then
+                echo "repositories=${analyzer}" | tee -a "$GITHUB_OUTPUT"
+              else
+                echo "repositories=${caller},${analyzer}" | tee -a "$GITHUB_OUTPUT"
+              fi
+
         - name: Generate token for GitHub
           id: generate-github-token
           # Always generate: the token is consumed by both the silence-check
@@ -87,9 +105,11 @@ runs:
               vault-auth-role-id: ${{ inputs.vault_role_id }}
               vault-auth-secret-id: ${{ inputs.vault_secret_id }}
               vault-url: ${{ inputs.vault_addr }}
-              # we generate a token with access to all assigned repos for the analyzer trigger
+              # Scoped to the two repositories actually used, resolved above. This was
+              # previously '!all', which issues a token valid for every repository of the
+              # installation.
               owner: camunda
-              repositories: '!all'
+              repositories: ${{ steps.token-scope.outputs.repositories }}
 
         - name: Check for Silence Issue
           id: silence-check

--- a/.github/actions/report-failure-on-slack/action.yml
+++ b/.github/actions/report-failure-on-slack/action.yml
@@ -71,54 +71,26 @@ outputs:
 runs:
     using: composite
     steps:
-        - name: Resolve which repositories the token needs
-          id: token-scope
-          shell: bash
-          run: |
-              set -euo pipefail
-              # The token has exactly two consumers, and between them they touch two
-              # repositories:
-              #   - the silence check reads issues on the calling repository
-              #   - the analyzer trigger dispatches a workflow in infraex-common-config
-              # Anything wider is granted for no reason.
-              caller="${GITHUB_REPOSITORY#*/}"
-              analyzer="infraex-common-config"
-              if [ "${caller}" = "${analyzer}" ]; then
-                echo "repositories=${analyzer}" | tee -a "$GITHUB_OUTPUT"
-              else
-                echo "repositories=${caller},${analyzer}" | tee -a "$GITHUB_OUTPUT"
-              fi
-
-        - name: Generate token for GitHub
-          id: generate-github-token
-          # Always generate: the token is consumed by both the silence-check
-          # step and the analyzer trigger step, so gating it on
-          # disable_silence_check leaves the trigger step without a token
-          # when the silence check is disabled.
-          uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
-          with:
-              github-app-id-vault-key: GITHUB_APP_ID
-              github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common
-              github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
-              github-app-private-key-vault-path: secret/data/products/infrastructure-experience/ci/common
-              vault-auth-method: approle
-              vault-auth-role-id: ${{ inputs.vault_role_id }}
-              vault-auth-secret-id: ${{ inputs.vault_secret_id }}
-              vault-url: ${{ inputs.vault_addr }}
-              # Scoped to the two repositories actually used, resolved above. This was
-              # previously '!all', which issues a token valid for every repository of the
-              # installation.
-              owner: camunda
-              repositories: ${{ steps.token-scope.outputs.repositories }}
-
         - name: Check for Silence Issue
           id: silence-check
           if: ${{ inputs.disable_silence_check == 'false' }}
           shell: bash
           continue-on-error: true
           run: |
+              set -euo pipefail
               ISSUE_TITLE="silence: ${GITHUB_WORKFLOW}"
-              ISSUE_SEARCH=$(gh issue list --repo ${{ github.repository }} --state open --search "$ISSUE_TITLE in:title" --label "alert-management" --json number,title,url)
+
+              # The silence issues live in the calling repository, so this reads them with the
+              # caller's own GITHUB_TOKEN. No App token is involved: one that had to cover the
+              # caller could fail to be issued when the installation does not, and that failure
+              # would cost the alert itself.
+              if ! ISSUE_SEARCH=$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open \
+                    --search "${ISSUE_TITLE} in:title" --label "alert-management" \
+                    --json number,title,url 2>&1); then
+                echo "::warning::Could not read issues on ${GITHUB_REPOSITORY}; silencing is disabled and this alert will be sent. Grant 'issues: read' to the job calling this action to enable it."
+                echo "${ISSUE_SEARCH}"
+                exit 1
+              fi
               ISSUE_COUNT=$(echo "$ISSUE_SEARCH" | jq '. | length')
 
               if [ "$ISSUE_COUNT" -gt 0 ]; then
@@ -131,7 +103,7 @@ runs:
                 exit 1
               fi
           env:
-              GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+              GITHUB_TOKEN: ${{ github.token }}
 
         - name: Compute failure cache key
           id: cache-key
@@ -327,6 +299,28 @@ runs:
                   }
           env:
               WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+        # Minted here rather than at the top of the action: the analyzer trigger is now its
+        # only consumer, so it is gated on the same condition and no token is created at all
+        # when a silence issue suppressed the alert.
+        - name: Generate token for GitHub
+          id: generate-github-token
+          if: ${{ steps.silence-check.outcome != 'success' }}
+          uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
+          with:
+              github-app-id-vault-key: GITHUB_APP_ID
+              github-app-id-vault-path: secret/data/products/infrastructure-experience/ci/common
+              github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
+              github-app-private-key-vault-path: secret/data/products/infrastructure-experience/ci/common
+              vault-auth-method: approle
+              vault-auth-role-id: ${{ inputs.vault_role_id }}
+              vault-auth-secret-id: ${{ inputs.vault_secret_id }}
+              vault-url: ${{ inputs.vault_addr }}
+              # The workflow dispatched below lives in infraex-common-config, whoever is
+              # calling. One fixed repository, so the token never has to cover the caller.
+              # This was '!all', which issues a token for every repository of the installation.
+              owner: camunda
+              repositories: infraex-common-config
 
         - name: Trigger GHA Failure Log Analyzer
           id: trigger-analyzer

--- a/.github/workflows/azure_nightly_cleanup.yml
+++ b/.github/workflows/azure_nightly_cleanup.yml
@@ -135,9 +135,11 @@ jobs:
 
     notify-on-failure:
         runs-on: ubuntu-latest
-        # The Slack action talks to GitHub with a Vault-issued App token, not GITHUB_TOKEN.
         permissions:
             contents: read
+            # The Slack action checks for an open "silence: <workflow>" issue in this
+            # repository before alerting, and reads it with this token.
+            issues: read
         if: failure()
         needs:
             - azure-cleanup


### PR DESCRIPTION
## Problem

`report-failure-on-slack` mints its App token with:

```yaml
# we generate a token with access to all assigned repos for the analyzer trigger
owner: camunda
repositories: '!all'
```

`!all` issues a token valid for **every repository of the installation**, with every
permission the App holds. The stated reason — the analyzer trigger — does not hold: that
trigger targets a hardcoded repository.

Six repositories call this action (`infraex-common-config`, `camunda-deployment-references`,
`infraex-terraform`, `keycloak`, `team-infrastructure-experience`, `c8-multi-region`) across
nightly cleanups, audits, drift detection, link checks and releases. The token is minted on
every one of those failures.

## Why the obvious fix was the wrong one

The first version of this branch scoped the token to *caller + `infraex-common-config`*. That
narrows it, and introduces a failure mode: `create-github-app-token` **fails** when a listed
repository is outside the installation. `!all` did not — it returned a token, the silence
check 404'd, `continue-on-error: true` swallowed it, and the alert went out anyway.

So a caller outside the installation would have gone from *alert sent without a silence
check* to *no alert at all*. For an alerting action that is a bad trade, and it is not
something I could verify from here.

## What this does instead

The App token only had to cover the caller because of the silence check. And the silence
check reads issues on the caller's **own** repository — precisely what the ambient
`GITHUB_TOKEN` is for.

| use | credential | scope |
| --- | --- | --- |
| silence check | `${{ github.token }}` | the current repository, by construction |
| analyzer trigger | App token | `repositories: infraex-common-config` |

The App token never names the caller, so it cannot fail because of one. The failure mode is
removed rather than handled, and the scope goes from *every repository of the installation*
to **one fixed repository**, identical for all six callers.

## Two consequences

**The App token is now single-purpose, so it is minted late.** It is created immediately
before the trigger and gated on the same condition, so no token is created at all when a
silence issue already suppressed the alert. Same reasoning as camunda/infraex-common-config#550.

**The silence check now needs `issues: read` on the calling job.** Audited the three callers
in this repository:

| workflow | job | before |
| --- | --- | --- |
| `aws_nightly_cleanup.yml` | `notify-on-failure` | no `permissions:` block — inherits, fine |
| `permanent_resources_audit.yml` | `notify-on-failure` | no `permissions:` block — inherits, fine |
| `azure_nightly_cleanup.yml` | `notify-on-failure` | `contents: read` — **would break** |

Exactly one, and it broke because I tightened it to `contents: read` in
camunda/infraex-common-config#551. Fixed in this PR.

External callers are not audited. Where the permission is missing the read fails, the step
logs a warning naming it, and the alert is sent:

```
::warning::Could not read issues on <repo>; silencing is disabled and this alert will be
sent. Grant 'issues: read' to the job calling this action to enable it.
```

Silencing degrades; the alert never does. That is the direction this should fail in, and
unlike the current silent 404 it says so.

## Also

`--repo ${{ github.repository }}` moved out of the `run:` body to `$GITHUB_REPOSITORY`, the
same pattern as camunda/infraex-common-config#556. Not attacker-controllable, but the file
uses `env:` everywhere else now.

## What this does not do

It narrows *which repositories*, not *which permissions* — the token still carries everything
the App holds on `infraex-common-config`, where the trigger needs `actions: write`.
`generate-github-app-token-from-vault-secrets` exposes no `permissions` input; raised as
camunda/infra-global-github-actions#778.

## Verification

- `pre-commit run --all-files` → green, `actionlint` and `zizmor` included.
- `zizmor --min-severity=high .github/` → clean.
- Action YAML parses.
- No runtime exercise: the token step needs Vault credentials and the action only runs on a
  workflow failure.
