### PR TITLE
feat(actions): add the shared observe-build-status composite action [ready]

### DIFF
--- a/.github/actions/observe-build-status/README.md
+++ b/.github/actions/observe-build-status/README.md
@@ -1,0 +1,111 @@
+# Observe Build Status
+
+## Description
+
+Reports a job's outcome, duration and runner resource usage to CI Analytics (BigQuery),
+for the InfraEx repository fleet.
+
+Pair it with `camunda/infra-global-github-actions/start-build-monitor`, which must be the
+**first** step of the job: it starts the resource sampler and drops the `/tmp/_monitor-start.pid`
+timestamp file this action reads to compute the duration. Call this action as the **last**
+step, with `if: always()` so failed and cancelled jobs are reported too, and
+`continue-on-error: true` so analytics can never fail a build.
+
+The CI Analytics service-account key is read from Vault at
+`secret/data/products/infrastructure-experience/ci/ci-analytics`, which is a constant for the
+whole InfraEx fleet — callers only supply credentials, never the path. Authenticate with
+either JWT/OIDC (preferred: no long-lived credential) or AppRole. When neither set of inputs
+is provided the action is a silent no-op, so forks and local runs are unaffected.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `build_status` | <p>Outcome of the job, normally <code>${{ job.status }}</code>: one of <code>success</code>, <code>failure</code>, <code>cancelled</code>.</p> | `true` | `""` |
+| `job_name` | <p>Name recorded in the <code>job_name</code> column. Defaults to <code>$GITHUB_JOB</code> when omitted, which is ambiguous for matrix jobs — pass <code>${{ github.job }}/${{ matrix.&lt;key&gt; }}</code> so each matrix leg is distinguishable. Use <code>/</code> as the separator consistently: matrix values often contain <code>-</code>, which makes the field unsplittable otherwise.</p> | `false` | `""` |
+| `user_reason` | <p>Optional string (200 chars max) categorising why the job ended this way, e.g. <code>flaky-tests</code>.</p> | `false` | `""` |
+| `user_description` | <p>Optional string (1000 chars max) detailing <code>user_reason</code>, e.g. the list of flaky tests.</p> | `false` | `""` |
+| `vault_addr` | <p>Vault server URL. Required for either authentication method; leave empty to disable reporting entirely.</p> | `false` | `""` |
+| `vault_jwt_path` | <p>Vault JWT auth mount path. JWT/OIDC authentication, preferred over AppRole.</p> | `false` | `""` |
+| `vault_jwt_role` | <p>Vault JWT auth role. Selects JWT authentication. The calling job needs <code>permissions: id-token: write</code> for GitHub to mint the OIDC token.</p> | `false` | `""` |
+| `vault_jwt_audience` | <p>Vault JWT GitHub audience.</p> | `false` | `""` |
+| `vault_role_id` | <p>Vault AppRole role ID. Only used when <code>vault_jwt_role</code> is empty; prefer JWT, which needs no long-lived credential stored as a repository secret.</p> | `false` | `""` |
+| `vault_secret_id` | <p>Vault AppRole secret ID. See <code>vault_role_id</code>.</p> | `false` | `""` |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/infraex-common-config/.github/actions/observe-build-status@main
+  with:
+    build_status:
+    # Outcome of the job, normally `${{ job.status }}`: one of `success`, `failure`, `cancelled`.
+    #
+    # Required: true
+    # Default: ""
+
+    job_name:
+    # Name recorded in the `job_name` column. Defaults to `$GITHUB_JOB` when omitted, which is
+    # ambiguous for matrix jobs — pass `${{ github.job }}/${{ matrix.<key> }}` so each matrix
+    # leg is distinguishable. Use `/` as the separator consistently: matrix values often
+    # contain `-`, which makes the field unsplittable otherwise.
+    #
+    # Required: false
+    # Default: ""
+
+    user_reason:
+    # Optional string (200 chars max) categorising why the job ended this way, e.g. `flaky-tests`.
+    #
+    # Required: false
+    # Default: ""
+
+    user_description:
+    # Optional string (1000 chars max) detailing `user_reason`, e.g. the list of flaky tests.
+    #
+    # Required: false
+    # Default: ""
+
+    vault_addr:
+    # Vault server URL. Required for either authentication method; leave empty to disable
+    # reporting entirely.
+    #
+    # Required: false
+    # Default: ""
+
+    vault_jwt_path:
+    # Vault JWT auth mount path. JWT/OIDC authentication, preferred over AppRole.
+    #
+    # Required: false
+    # Default: ""
+
+    vault_jwt_role:
+    # Vault JWT auth role. Selects JWT authentication. The calling job needs
+    # `permissions: id-token: write` for GitHub to mint the OIDC token.
+    #
+    # Required: false
+    # Default: ""
+
+    vault_jwt_audience:
+    # Vault JWT GitHub audience.
+    #
+    # Required: false
+    # Default: ""
+
+    vault_role_id:
+    # Vault AppRole role ID. Only used when `vault_jwt_role` is empty; prefer JWT, which needs
+    # no long-lived credential stored as a repository secret.
+    #
+    # Required: false
+    # Default: ""
+
+    vault_secret_id:
+    # Vault AppRole secret ID. See `vault_role_id`.
+    #
+    # Required: false
+    # Default: ""
+```

--- a/.github/actions/observe-build-status/README.md
+++ b/.github/actions/observe-build-status/README.md
@@ -8,14 +8,16 @@ for the InfraEx repository fleet.
 Pair it with `camunda/infra-global-github-actions/start-build-monitor`, which must be the
 **first** step of the job: it starts the resource sampler and drops the `/tmp/_monitor-start.pid`
 timestamp file this action reads to compute the duration. Call this action as the **last**
-step, with `if: always()` so failed and cancelled jobs are reported too, and
-`continue-on-error: true` so analytics can never fail a build.
+step, with `if: always()` so failed and cancelled jobs are reported too.
+
+Every step here is best-effort: the action reports what it can and never fails the job it is
+measuring, so callers do not have to remember `continue-on-error: true`.
 
 The CI Analytics service-account key is read from Vault at
 `secret/data/products/infrastructure-experience/ci/ci-analytics`, which is a constant for the
 whole InfraEx fleet — callers only supply credentials, never the path. Authenticate with
-either JWT/OIDC (preferred: no long-lived credential) or AppRole. When neither set of inputs
-is provided the action is a silent no-op, so forks and local runs are unaffected.
+either JWT/OIDC (preferred: no long-lived credential) or AppRole. Leave `vault_addr` empty to
+disable reporting entirely, so forks and local runs are unaffected.
 
 
 ## Inputs
@@ -28,9 +30,9 @@ is provided the action is a silent no-op, so forks and local runs are unaffected
 | `user_description` | <p>Optional string (1000 chars max) detailing <code>user_reason</code>, e.g. the list of flaky tests.</p> | `false` | `""` |
 | `vault_addr` | <p>Vault server URL. Required for either authentication method; leave empty to disable reporting entirely.</p> | `false` | `""` |
 | `vault_jwt_path` | <p>Vault JWT auth mount path. JWT/OIDC authentication, preferred over AppRole.</p> | `false` | `""` |
-| `vault_jwt_role` | <p>Vault JWT auth role. Selects JWT authentication. The calling job needs <code>permissions: id-token: write</code> for GitHub to mint the OIDC token.</p> | `false` | `""` |
+| `vault_jwt_role` | <p>Vault JWT auth role. Setting it selects JWT authentication, and together with <code>vault_addr</code> it is the complete JWT credential set. The calling job needs <code>permissions: id-token: write</code> for GitHub to mint the OIDC token.</p> | `false` | `""` |
 | `vault_jwt_audience` | <p>Vault JWT GitHub audience.</p> | `false` | `""` |
-| `vault_role_id` | <p>Vault AppRole role ID. Only used when <code>vault_jwt_role</code> is empty; prefer JWT, which needs no long-lived credential stored as a repository secret.</p> | `false` | `""` |
+| `vault_role_id` | <p>Vault AppRole role ID. Only used when <code>vault_jwt_role</code> is empty, and only together with <code>vault_secret_id</code> — both are required for the AppRole set to count as complete. Prefer JWT, which needs no long-lived credential stored as a repository secret.</p> | `false` | `""` |
 | `vault_secret_id` | <p>Vault AppRole secret ID. See <code>vault_role_id</code>.</p> | `false` | `""` |
 
 
@@ -84,7 +86,8 @@ This action is a `composite` action.
     # Default: ""
 
     vault_jwt_role:
-    # Vault JWT auth role. Selects JWT authentication. The calling job needs
+    # Vault JWT auth role. Setting it selects JWT authentication, and together with
+    # `vault_addr` it is the complete JWT credential set. The calling job needs
     # `permissions: id-token: write` for GitHub to mint the OIDC token.
     #
     # Required: false
@@ -97,8 +100,9 @@ This action is a `composite` action.
     # Default: ""
 
     vault_role_id:
-    # Vault AppRole role ID. Only used when `vault_jwt_role` is empty; prefer JWT, which needs
-    # no long-lived credential stored as a repository secret.
+    # Vault AppRole role ID. Only used when `vault_jwt_role` is empty, and only together with
+    # `vault_secret_id` — both are required for the AppRole set to count as complete. Prefer
+    # JWT, which needs no long-lived credential stored as a repository secret.
     #
     # Required: false
     # Default: ""

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -7,14 +7,16 @@ description: |
     Pair it with `camunda/infra-global-github-actions/start-build-monitor`, which must be the
     **first** step of the job: it starts the resource sampler and drops the `/tmp/_monitor-start.pid`
     timestamp file this action reads to compute the duration. Call this action as the **last**
-    step, with `if: always()` so failed and cancelled jobs are reported too, and
-    `continue-on-error: true` so analytics can never fail a build.
+    step, with `if: always()` so failed and cancelled jobs are reported too.
+
+    Every step here is best-effort: the action reports what it can and never fails the job it is
+    measuring, so callers do not have to remember `continue-on-error: true`.
 
     The CI Analytics service-account key is read from Vault at
     `secret/data/products/infrastructure-experience/ci/ci-analytics`, which is a constant for the
     whole InfraEx fleet — callers only supply credentials, never the path. Authenticate with
-    either JWT/OIDC (preferred: no long-lived credential) or AppRole. When neither set of inputs
-    is provided the action is a silent no-op, so forks and local runs are unaffected.
+    either JWT/OIDC (preferred: no long-lived credential) or AppRole. Leave `vault_addr` empty to
+    disable reporting entirely, so forks and local runs are unaffected.
 
 inputs:
     build_status:
@@ -45,7 +47,8 @@ inputs:
         required: false
     vault_jwt_role:
         description: |
-            Vault JWT auth role. Selects JWT authentication. The calling job needs
+            Vault JWT auth role. Setting it selects JWT authentication, and together with
+            `vault_addr` it is the complete JWT credential set. The calling job needs
             `permissions: id-token: write` for GitHub to mint the OIDC token.
         required: false
     vault_jwt_audience:
@@ -53,8 +56,9 @@ inputs:
         required: false
     vault_role_id:
         description: |
-            Vault AppRole role ID. Only used when `vault_jwt_role` is empty; prefer JWT, which needs
-            no long-lived credential stored as a repository secret.
+            Vault AppRole role ID. Only used when `vault_jwt_role` is empty, and only together with
+            `vault_secret_id` — both are required for the AppRole set to count as complete. Prefer
+            JWT, which needs no long-lived credential stored as a repository secret.
         required: false
     vault_secret_id:
         description: Vault AppRole secret ID. See `vault_role_id`.
@@ -85,10 +89,11 @@ runs:
 
         # AppRole is the migration path for repositories that have not moved to OIDC yet. It is
         # skipped as soon as a JWT role is configured, so a repository can carry both sets of
-        # inputs while it migrates.
+        # inputs while it migrates. Both AppRole inputs are required: attempting auth with a
+        # half-configured set only produces a failure and a misleading "Vault read failed" warning.
         - name: Import CI Analytics secret (AppRole)
           id: secrets-approle
-          if: ${{ inputs.vault_addr != '' && inputs.vault_jwt_role == '' && inputs.vault_role_id != '' }}
+          if: ${{ inputs.vault_addr != '' && inputs.vault_jwt_role == '' && inputs.vault_role_id != '' && inputs.vault_secret_id != '' }}
           continue-on-error: true
           uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4
           with:
@@ -100,14 +105,26 @@ runs:
               secrets: |
                   secret/data/products/infrastructure-experience/ci/ci-analytics gcloud_sa_key;
 
-        # Warn only when reporting was actually requested. A caller that configured no Vault
-        # credentials at all wants a no-op, and does not need an annotation on every job.
+        # `vault_addr` is the opt-in switch, so setting it without a complete credential set is a
+        # configuration mistake rather than an opt-out. Say so explicitly: silently doing nothing
+        # here would leave a repository believing it is reporting metrics when it is not.
+        - name: Check Vault configuration
+          if: >-
+              ${{ inputs.vault_addr != ''
+              && inputs.vault_jwt_role == ''
+              && !(inputs.vault_role_id != '' && inputs.vault_secret_id != '') }}
+          shell: bash
+          run: |
+              echo "::warning::Not sending CI health metrics: vault_addr is set but no complete credential set was supplied. Provide vault_jwt_role (JWT, preferred), or both vault_role_id and vault_secret_id (AppRole). Leave vault_addr empty to disable reporting on purpose."
+
+        # Only reachable when credentials were actually supplied, so this always means a real
+        # failure — a Vault outage, or a role without a policy on the CI Analytics path.
         - name: Check CI Analytics secret availability
           if: >-
-              inputs.vault_addr != ''
-              && (inputs.vault_jwt_role != '' || inputs.vault_role_id != '')
+              ${{ inputs.vault_addr != ''
+              && (inputs.vault_jwt_role != '' || (inputs.vault_role_id != '' && inputs.vault_secret_id != ''))
               && steps.secrets-jwt.outputs.gcloud_sa_key == ''
-              && steps.secrets-approle.outputs.gcloud_sa_key == ''
+              && steps.secrets-approle.outputs.gcloud_sa_key == '' }}
           shell: bash
           run: |
               echo "::warning::Not sending CI health metrics: could not read the CI Analytics secret from Vault. Check that the Vault role has a policy on secret/data/products/infrastructure-experience/ci/ci-analytics."
@@ -115,6 +132,7 @@ runs:
         - name: Get build duration in milliseconds
           id: duration
           if: ${{ steps.secrets-jwt.outputs.gcloud_sa_key != '' || steps.secrets-approle.outputs.gcloud_sa_key != '' }}
+          continue-on-error: true # a duration we cannot compute must not fail the job being measured
           shell: bash
           run: |
               set -euo pipefail
@@ -143,6 +161,7 @@ runs:
 
         - name: Submit build status
           if: ${{ always() && (steps.secrets-jwt.outputs.gcloud_sa_key != '' || steps.secrets-approle.outputs.gcloud_sa_key != '') }}
+          continue-on-error: true # BigQuery or network trouble must not fail the job being measured
           uses: camunda/infra-global-github-actions/submit-build-status@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
           with:
               job_name_override: ${{ inputs.job_name }}

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -1,0 +1,153 @@
+---
+name: Observe Build Status
+description: |
+    Reports a job's outcome, duration and runner resource usage to CI Analytics (BigQuery),
+    for the InfraEx repository fleet.
+
+    Pair it with `camunda/infra-global-github-actions/start-build-monitor`, which must be the
+    **first** step of the job: it starts the resource sampler and drops the `/tmp/_monitor-start.pid`
+    timestamp file this action reads to compute the duration. Call this action as the **last**
+    step, with `if: always()` so failed and cancelled jobs are reported too, and
+    `continue-on-error: true` so analytics can never fail a build.
+
+    The CI Analytics service-account key is read from Vault at
+    `secret/data/products/infrastructure-experience/ci/ci-analytics`, which is a constant for the
+    whole InfraEx fleet — callers only supply credentials, never the path. Authenticate with
+    either JWT/OIDC (preferred: no long-lived credential) or AppRole. When neither set of inputs
+    is provided the action is a silent no-op, so forks and local runs are unaffected.
+
+inputs:
+    build_status:
+        description: |
+            Outcome of the job, normally `${{ job.status }}`: one of `success`, `failure`, `cancelled`.
+        required: true
+    job_name:
+        description: |
+            Name recorded in the `job_name` column. Defaults to `$GITHUB_JOB` when omitted, which is
+            ambiguous for matrix jobs — pass `${{ github.job }}/${{ matrix.<key> }}` so each matrix
+            leg is distinguishable. Use `/` as the separator consistently: matrix values often
+            contain `-`, which makes the field unsplittable otherwise.
+        required: false
+    user_reason:
+        description: Optional string (200 chars max) categorising why the job ended this way, e.g. `flaky-tests`.
+        required: false
+    user_description:
+        description: Optional string (1000 chars max) detailing `user_reason`, e.g. the list of flaky tests.
+        required: false
+
+    vault_addr:
+        description: |
+            Vault server URL. Required for either authentication method; leave empty to disable
+            reporting entirely.
+        required: false
+    vault_jwt_path:
+        description: Vault JWT auth mount path. JWT/OIDC authentication, preferred over AppRole.
+        required: false
+    vault_jwt_role:
+        description: |
+            Vault JWT auth role. Selects JWT authentication. The calling job needs
+            `permissions: id-token: write` for GitHub to mint the OIDC token.
+        required: false
+    vault_jwt_audience:
+        description: Vault JWT GitHub audience.
+        required: false
+    vault_role_id:
+        description: |
+            Vault AppRole role ID. Only used when `vault_jwt_role` is empty; prefer JWT, which needs
+            no long-lived credential stored as a repository secret.
+        required: false
+    vault_secret_id:
+        description: Vault AppRole secret ID. See `vault_role_id`.
+        required: false
+
+runs:
+    using: composite
+    steps:
+        # Composite actions cannot read the `secrets` context, so callers pass the Vault
+        # configuration as inputs and it resolves here through `inputs.*`.
+        #
+        # `continue-on-error` on both auth steps is deliberate: a Vault outage, a missing policy or
+        # a fork PR without secrets must degrade to "no metrics", never fail the job being measured.
+        - name: Import CI Analytics secret (JWT)
+          id: secrets-jwt
+          if: ${{ inputs.vault_addr != '' && inputs.vault_jwt_role != '' }}
+          continue-on-error: true
+          uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4
+          with:
+              url: ${{ inputs.vault_addr }}
+              method: jwt
+              path: ${{ inputs.vault_jwt_path }}
+              role: ${{ inputs.vault_jwt_role }}
+              jwtGithubAudience: ${{ inputs.vault_jwt_audience }}
+              exportEnv: false # step outputs are enough; keep the key out of the job environment
+              secrets: |
+                  secret/data/products/infrastructure-experience/ci/ci-analytics gcloud_sa_key;
+
+        # AppRole is the migration path for repositories that have not moved to OIDC yet. It is
+        # skipped as soon as a JWT role is configured, so a repository can carry both sets of
+        # inputs while it migrates.
+        - name: Import CI Analytics secret (AppRole)
+          id: secrets-approle
+          if: ${{ inputs.vault_addr != '' && inputs.vault_jwt_role == '' && inputs.vault_role_id != '' }}
+          continue-on-error: true
+          uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4
+          with:
+              url: ${{ inputs.vault_addr }}
+              method: approle
+              roleId: ${{ inputs.vault_role_id }}
+              secretId: ${{ inputs.vault_secret_id }}
+              exportEnv: false # step outputs are enough; keep the key out of the job environment
+              secrets: |
+                  secret/data/products/infrastructure-experience/ci/ci-analytics gcloud_sa_key;
+
+        # Warn only when reporting was actually requested. A caller that configured no Vault
+        # credentials at all wants a no-op, and does not need an annotation on every job.
+        - name: Check CI Analytics secret availability
+          if: >-
+              inputs.vault_addr != ''
+              && (inputs.vault_jwt_role != '' || inputs.vault_role_id != '')
+              && steps.secrets-jwt.outputs.gcloud_sa_key == ''
+              && steps.secrets-approle.outputs.gcloud_sa_key == ''
+          shell: bash
+          run: |
+              echo "::warning::Not sending CI health metrics: could not read the CI Analytics secret from Vault. Check that the Vault role has a policy on secret/data/products/infrastructure-experience/ci/ci-analytics."
+
+        - name: Get build duration in milliseconds
+          id: duration
+          if: ${{ steps.secrets-jwt.outputs.gcloud_sa_key != '' || steps.secrets-approle.outputs.gcloud_sa_key != '' }}
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              # start-build-monitor creates this file as its first action, so its mtime is the
+              # closest available proxy for the job start. Deriving the anchor from anything else
+              # (the checkout, the action directory) silently under-reports by however long setup
+              # took, and a wrong duration is worse than a missing one in a duration dashboard.
+              if [ ! -f /tmp/_monitor-start.pid ]; then
+                echo "::warning::Not sending build duration: start-build-monitor did not create /tmp/_monitor-start.pid. Is it the first step of this job?"
+                echo "result=" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+
+              start=$(date -r /tmp/_monitor-start.pid +'%s')
+              now=$(date +'%s')
+              duration=$(( now - start ))
+
+              # Only submit plausible durations, between 0 and 72 hours.
+              if (( duration >= 0 && duration <= 259200 )); then
+                echo "result=$(( duration * 1000 ))" >> "$GITHUB_OUTPUT"
+              else
+                echo "::warning::Not sending build duration: computed ${duration}s, outside the expected range."
+                echo "result=" >> "$GITHUB_OUTPUT"
+              fi
+
+        - name: Submit build status
+          if: ${{ always() && (steps.secrets-jwt.outputs.gcloud_sa_key != '' || steps.secrets-approle.outputs.gcloud_sa_key != '') }}
+          uses: camunda/infra-global-github-actions/submit-build-status@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
+          with:
+              job_name_override: ${{ inputs.job_name }}
+              build_status: ${{ inputs.build_status }}
+              build_duration_millis: ${{ steps.duration.outputs.result }}
+              user_reason: ${{ inputs.user_reason }}
+              user_description: ${{ inputs.user_description }}
+              gcp_credentials_json: ${{ steps.secrets-jwt.outputs.gcloud_sa_key || steps.secrets-approle.outputs.gcloud_sa_key }}


### PR DESCRIPTION
## Why

CI Analytics reporting is currently being vendored per repository. camunda/keycloak#622 and camunda/camunda-deployment-references#2975 introduce two copies of the same ~98-line action, opened days apart by the same author.

I diffed the two. The **only** functional difference is the Vault authentication method:

| | keycloak#622 | CDR#2975 |
| --- | --- | --- |
| auth | `method: jwt` + `id-token: write` | `method: approle` |
| Vault path | `secret/data/products/infrastructure-experience/ci/ci-analytics` | **identical** |
| `submit-build-status` pin | `66bf6e26… # main` | `951c097e… # PR 781` |
| `vault-action` pin | `892a2682… # v4.0.0` | `892a2682… # v4` (same SHA) |
| `build_status` doc | `success, failure, cancelled` | `success, failure, aborted, cancelled` |
| `user_description` doc | 200 chars | 1000 chars (upstream says 1000 — keycloak's is wrong) |
| "secret unavailable" guard | fires even with no Vault inputs | guarded on the inputs |
| duration logic | identical | identical |

Everything below the first row is copy drift that appeared within days. That is the argument for extracting now rather than later.

## Why here

1. **No copy exists yet.** Across the nine InfraEx repositories (`c8-sm-checks`, `camunda-deployment-references`, `camunda-infrastructure-experience-interview`, `-tools`, `infraex-common-config`, `infraex-terraform`, `keycloak`, `team-infrastructure-experience`, `vendor-container-images`), `observe-build-status` is vendored in **zero** of them on `main`. The two PRs above are copies 1 and 2 — this is the cheapest possible moment.
2. **Eight of the nine already consume composite actions from here**, SHA-pinned to a release tag: `asdf-install-tooling`, `report-failure-on-slack`, `report-warning-on-slack`.
3. **Per-repository variance is zero.** Within the fleet the Vault path is a constant, so callers supply credentials and never the path. Contrast `camunda/infra-core` (`products/infra/…`) and `camunda/camunda` (`products/zeebe/…`), which have a real reason to keep their own copy.
4. It **removes a downstream fork**. keycloak#622 also carries a 53-line copy of `docker_update_action_readmes.sh`, patched solely to rewrite the generated usage line for a repo-internal action — and that fork silently dropped the `node` **digest pin** this repository added deliberately (see the comment at `pre_commit_hooks/docker_update_action_readmes.sh:19-35`). Here the stock hook generates the correct usage line by construction:
   ```yaml
   - uses: camunda/infraex-common-config/.github/actions/observe-build-status@main
   ```

## Design notes

- **Both auth methods are supported**, so a repository can adopt this without migrating its Vault setup first. JWT is preferred and documented as such (no long-lived `secret_id` in repository secrets); AppRole is skipped as soon as `vault_jwt_role` is set, so both input sets can coexist during a migration.
- **Reporting never fails the job being measured**: both auth steps are `continue-on-error`, and the "could not read the secret" warning only fires when Vault credentials were actually supplied — so forks, local runs and repositories that opt out stay silent instead of collecting a `::warning::` annotation on every job.
- **Input names follow the existing convention** in this repository (`vault_addr` / `vault_role_id` / `vault_secret_id`, as in `report-failure-on-slack`), extended with `vault_jwt_path` / `vault_jwt_role` / `vault_jwt_audience`.
- **Duration anchor**: `/tmp/_monitor-start.pid`, written by `start-build-monitor`. If it is absent the action emits a warning and omits `build_duration_millis` rather than falling back to the checkout time, which would silently under-report by however long job setup took.
- `job_name` documents the `/` separator convention for matrix jobs, since matrix values routinely contain `-` and the BigQuery column is otherwise unsplittable.

## Validation

- `pre-commit run --all-files` clean, including `zizmor --min-severity=high` with the repository's `'*': hash-pin` policy — both `vault-action` and `submit-build-status` are full-SHA pinned.
- README generated by the repository's own `update-action-readmes-docker` hook, unmodified.
- The step sequence is the one already proven end-to-end in [camunda/keycloak run 31689628694](https://github.com/camunda/keycloak/actions/runs/31689628694): Vault read, `job_name` `build-image/26-hub`, `build_duration_milliseconds` `428000`, BigQuery `tableDataInsertAllResponse` with no `insertErrors`.

## Follow-up

Once this is released, camunda/keycloak#622 and camunda/camunda-deployment-references#2975 drop their vendored `action.yml` + `README.md` (and keycloak drops its forked pre-commit hook), keeping only the workflow wiring.

Related: camunda/team-infrastructure#1080