### PR TITLE
feat(workflows): add commit-patch-global, the privileged half of the trust split [ready]

### DIFF
--- a/.github/workflows/commit-patch-global.yml
+++ b/.github/workflows/commit-patch-global.yml
@@ -1,0 +1,259 @@
+---
+name: commit-patch-global
+
+# Commits a patch produced by an untrusted job, from a job that holds the credential.
+#
+# This is the privileged half of a two-job split. The pattern it exists to support:
+#
+#   job 1   runs repository-supplied code -- build tooling, dependency updates, linters,
+#           pre-commit hooks. It holds no GitHub write credential, sets
+#           `persist-credentials: false`, and emits its result as a patch artifact.
+#
+#   job 2   is this workflow. It runs no repository code: pinned third-party actions,
+#           `git apply`, and a commit through the GitHub API. Applying a patch does not
+#           execute it, and `git apply` refuses paths outside the work tree.
+#
+# The point is that a dependency update, or a third-party lint hook, cannot execute next
+# to a token that can write to the repository. See the "CI trust boundary" section of the
+# README for when to reach for this and why.
+#
+# The patch is untrusted input. What is trustworthy here is the toolchain measuring it:
+# no repository code has run on this runner, so `git`, `wc` and `grep` cannot have been
+# shimmed to under-report. The guards below bound blast radius and refuse patches the
+# commit step would silently corrupt; they are not an injection defence, since a hostile
+# patch needs three lines, not a large one.
+#
+# Requires a `pull_request` context: the commit lands on `head-ref` via the GitHub API.
+
+on:
+    workflow_call:
+        inputs:
+            artifact-name:
+                description: Name of the artifact holding the patch, as uploaded by the unprivileged job.
+                required: true
+                type: string
+            patch-file-name:
+                description: Name of the patch file inside that artifact.
+                default: changes.patch
+                type: string
+            head-sha:
+                description: |
+                    The commit the patch was built from. Checked out here, and asserted to still be
+                    what the branch points at before committing. Pass the same value the unprivileged
+                    job checked out, normally `github.event.pull_request.head.sha`.
+                required: true
+                type: string
+            head-ref:
+                description: Branch the commit is pushed to, normally `github.event.pull_request.head.ref`.
+                required: true
+                type: string
+            commit-message:
+                description: Commit message.
+                required: true
+                type: string
+            max-patch-bytes:
+                description: |
+                    Refuse a patch larger than this. Set it above the largest legitimate output of the
+                    producing job -- a generator rewriting a large fixture corpus needs megabytes,
+                    whereas a formatter needs kilobytes -- because its purpose is catching a runaway,
+                    such as a .gitignore miss dumping build caches into the patch.
+                default: 65536
+                type: number
+            max-changed-lines:
+                description: |
+                    Refuse a patch touching more than this many lines. 0 disables it, which is the
+                    right setting whenever the producing job legitimately rewrites generated files:
+                    a line count says nothing useful about machine-written JSON. Where the commit is
+                    meant to stay human-readable, set it.
+                default: 0
+                type: number
+            refuse-paths-regex:
+                description: |
+                    Extended regular expression matched against every path in the patch. A match is
+                    refused. Empty disables it.
+
+                    Use it for paths the producing job has no business writing. CI definitions are
+                    the usual case -- `\.github/(workflows|actions)/|(^|/)\.gitmodules$` -- but only
+                    where they are genuinely out of scope: a formatter that reformats workflow YAML
+                    writes them legitimately, and would be refused.
+                default: ''
+                type: string
+            token-repositories:
+                description: |
+                    Repositories the installation token may act on. Empty means the calling repository,
+                    which is also what the token action defaults to; naming it stops the scope drifting
+                    if that default changes.
+                default: ''
+                type: string
+            vault-secret-path:
+                description: Vault path holding the GitHub App id and private key.
+                default: secret/data/products/infrastructure-experience/ci/common
+                type: string
+        secrets:
+            vault-addr:
+                required: true
+            vault-role-id:
+                required: true
+            vault-secret-id:
+                required: true
+
+# The write is carried by the App token, never by GITHUB_TOKEN, which only reads the
+# branch and the ref.
+permissions:
+    contents: read
+
+jobs:
+    commit:
+        name: Commit the patch
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            # No step in this job may run code from the branch: that is the whole point.
+            # Keep it to SHA-pinned third-party actions and git.
+            - name: Checkout the head commit
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  # By SHA, not by branch name: the patch has to be replayed onto exactly the
+                  # tree it was built from. A branch name would let a push in between move the
+                  # ground under this job.
+                  ref: ${{ inputs.head-sha }}
+                  # The commit is created through the GitHub API by the last step, which
+                  # receives the App token explicitly, so no write credential is needed here --
+                  # and the App token does not have to exist yet.
+                  persist-credentials: false
+
+            - name: Download the patch
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+              with:
+                  name: ${{ inputs.artifact-name }}
+                  path: ${{ runner.temp }}
+
+            - name: Check the patch is safe to commit
+              env:
+                  ARTIFACT_NAME: ${{ inputs.artifact-name }}
+                  PATCH_FILE_NAME: ${{ inputs.patch-file-name }}
+                  MAX_BYTES: ${{ inputs.max-patch-bytes }}
+                  MAX_LINES: ${{ inputs.max-changed-lines }}
+                  REFUSE_PATHS: ${{ inputs.refuse-paths-regex }}
+              run: |
+                  set -euo pipefail
+
+                  patch_path="${RUNNER_TEMP}/${PATCH_FILE_NAME}"
+                  if [ ! -s "$patch_path" ]; then
+                      echo "::error::${PATCH_FILE_NAME} is missing or empty in artifact '${ARTIFACT_NAME}'."
+                      exit 1
+                  fi
+
+                  numstat=$(git apply --numstat --binary "$patch_path")
+                  bytes=$(wc -c < "$patch_path" | tr -d ' ')
+                  files=$(printf '%s\n' "$numstat" | grep -c . || true)
+                  # Binary hunks report "-" for both counts; they are covered by the byte limit.
+                  lines=$(printf '%s\n' "$numstat" \
+                          | awk '{ if ($1 != "-") a += $1; if ($2 != "-") d += $2 } END { print a + d + 0 }')
+                  echo "Patch: ${files} file(s), ${lines} changed line(s), ${bytes} byte(s)."
+                  printf '%s\n' "$numstat"
+
+                  if [ "$bytes" -gt "$MAX_BYTES" ]; then
+                      echo "::error::The patch is ${bytes} bytes, over the ${MAX_BYTES}-byte limit; not committing it."
+                      echo "::error::Reproduce the job locally and commit the result yourself, or raise max-patch-bytes."
+                      exit 1
+                  fi
+
+                  if [ "$MAX_LINES" -gt 0 ] && [ "$lines" -gt "$MAX_LINES" ]; then
+                      echo "::error::The patch changes ${lines} lines, over the ${MAX_LINES}-line limit; not committing it."
+                      echo "::error::Reproduce the job locally and commit the result yourself, or raise max-changed-lines."
+                      exit 1
+                  fi
+
+                  # getsentry/action-github-commit sends every file to the API as
+                  # Buffer.from(content).toString(), i.e. decoded as UTF-8, and hardcodes mode
+                  # 100644. Binary content comes out mangled and permissions are lost. The patch
+                  # carries both faithfully -- it is measured and applied with --binary -- so
+                  # nothing upstream notices; refuse rather than commit something quietly wrong.
+                  # Deletions are fine: the action handles them with `sha: null`.
+                  if printf '%s\n' "$numstat" | awk '$1 == "-" && $2 == "-" { found = 1 } END { exit !found }'; then
+                      echo "::error::The patch changes binary files, which the commit step would corrupt."
+                      exit 1
+                  fi
+
+                  if grep -qE '^(old|new) mode ' "$patch_path" \
+                     || grep -E '^new file mode ' "$patch_path" | grep -qv ' 100644$'; then
+                      echo "::error::The patch changes file modes, which the commit step would flatten to 100644."
+                      exit 1
+                  fi
+
+                  # `cut -f3-` keeps the whole path field, so a rename with either side matching
+                  # is caught too.
+                  if [ -n "$REFUSE_PATHS" ] \
+                     && printf '%s\n' "$numstat" | cut -f3- | grep -qE "$REFUSE_PATHS"; then
+                      echo "::error::The patch touches paths this job is not allowed to write (${REFUSE_PATHS})."
+                      echo "::error::Inspect the pull request: this is a broken job, or branch code writing where it should not."
+                      exit 1
+                  fi
+
+            - name: Apply the patch
+              env:
+                  PATCH_FILE_NAME: ${{ inputs.patch-file-name }}
+              run: |
+                  set -euo pipefail
+
+                  patch_path="${RUNNER_TEMP}/${PATCH_FILE_NAME}"
+
+                  # `git apply` refuses paths outside the working tree, so the patch cannot reach
+                  # the runner's filesystem. It is applied, never executed.
+                  #
+                  # The changes are left unstaged on purpose: action-github-commit collects them
+                  # with `git ls-files -om`, which compares the working tree against the index.
+                  git apply --stat --binary "$patch_path"
+                  git apply --check --binary "$patch_path"
+                  if ! git apply --binary "$patch_path"; then
+                      echo "::error::Could not apply the patch. Re-run the workflow."
+                      exit 1
+                  fi
+
+            - name: Check the branch has not moved
+              # `git apply` matches context, not position, so a patch built from an older tree
+              # can still apply cleanly to a newer one. And the commit step takes its parent from
+              # the remote branch as it stands at that moment while sending the working tree's
+              # file contents: if the branch was pushed to while the producing job was working,
+              # that would quietly overwrite the newer version of every file in the patch.
+              #
+              # This narrows the window rather than closing it -- the commit call re-reads the
+              # ref seconds later and there is no compare-and-swap to hand -- but it turns the
+              # likely case into a loud failure, and the push that moved the branch has started
+              # its own run, which redoes the work.
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  HEAD_SHA: ${{ inputs.head-sha }}
+                  HEAD_REF: ${{ inputs.head-ref }}
+              run: |
+                  set -euo pipefail
+
+                  current=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${HEAD_REF}" --jq '.object.sha')
+                  if [ "$current" != "$HEAD_SHA" ]; then
+                      echo "::error::${HEAD_REF} moved from ${HEAD_SHA} to ${current} while the job was running; not committing a patch built from the old tree."
+                      exit 1
+                  fi
+                  echo "${HEAD_REF} is still at ${HEAD_SHA}."
+
+            # Minted last, deliberately: the token only needs to exist for the commit call, so
+            # it is not alive while the untrusted patch is downloaded, measured and applied.
+            - name: Generate token for GitHub
+              id: generate-github-token
+              uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@32a6e03de12f6c9c08a2e0590bb5aef2d69e9d6c # main
+              with:
+                  github-app-id-vault-key: GITHUB_APP_ID
+                  github-app-id-vault-path: ${{ inputs.vault-secret-path }}
+                  github-app-private-key-vault-key: GITHUB_APP_PRIVATE_KEY
+                  github-app-private-key-vault-path: ${{ inputs.vault-secret-path }}
+                  repositories: ${{ inputs.token-repositories || github.event.repository.name }}
+                  vault-auth-method: approle
+                  vault-auth-role-id: ${{ secrets.vault-role-id }}
+                  vault-auth-secret-id: ${{ secrets.vault-secret-id }}
+                  vault-url: ${{ secrets.vault-addr }}
+
+            - name: Commit the changes
+              uses: getsentry/action-github-commit@5972d5f578ad77306063449e718c0c2a6fbc4ae1 # v2.1.0
+              with:
+                  github-token: ${{ steps.generate-github-token.outputs.token }}
+                  message: ${{ inputs.commit-message }}

--- a/.github/workflows/commit-patch-global.yml
+++ b/.github/workflows/commit-patch-global.yml
@@ -144,20 +144,24 @@ jobs:
                       exit 1
                   fi
 
-                  numstat=$(git apply --numstat --binary "$patch_path")
+                  # Size first, before anything parses the patch. The job that produced it is
+                  # untrusted, so its own size check cannot be relied on -- it could upload
+                  # gigabytes. Running `git apply --numstat` on that would burn the runner
+                  # before the limit meant to catch it had been consulted.
                   bytes=$(wc -c < "$patch_path" | tr -d ' ')
+                  if [ "$bytes" -gt "$MAX_BYTES" ]; then
+                      echo "::error::The patch is ${bytes} bytes, over the ${MAX_BYTES}-byte limit; not committing it."
+                      echo "::error::Reproduce the job locally and commit the result yourself, or raise max-patch-bytes."
+                      exit 1
+                  fi
+
+                  numstat=$(git apply --numstat --binary "$patch_path")
                   files=$(printf '%s\n' "$numstat" | grep -c . || true)
                   # Binary hunks report "-" for both counts; they are covered by the byte limit.
                   lines=$(printf '%s\n' "$numstat" \
                           | awk '{ if ($1 != "-") a += $1; if ($2 != "-") d += $2 } END { print a + d + 0 }')
                   echo "Patch: ${files} file(s), ${lines} changed line(s), ${bytes} byte(s)."
                   printf '%s\n' "$numstat"
-
-                  if [ "$bytes" -gt "$MAX_BYTES" ]; then
-                      echo "::error::The patch is ${bytes} bytes, over the ${MAX_BYTES}-byte limit; not committing it."
-                      echo "::error::Reproduce the job locally and commit the result yourself, or raise max-patch-bytes."
-                      exit 1
-                  fi
 
                   if [ "$MAX_LINES" -gt 0 ] && [ "$lines" -gt "$MAX_LINES" ]; then
                       echo "::error::The patch changes ${lines} lines, over the ${MAX_LINES}-line limit; not committing it."

--- a/README.md
+++ b/README.md
@@ -115,3 +115,80 @@ This avoids a blind spot: auditing S3 per-region would silently skip any bucket 
 cloud-nuke does not report ELBv2 target groups. Target groups created for Kubernetes Services of type `LoadBalancer` (OpenShift router, ingress-nginx, Contour, Submariner, ...) are left behind when their load balancer or cluster is deleted, and they silently accumulate until they reach the regional **Target Groups per Region** quota (default 3000). Hitting the cap breaks new ingress load balancer creation with a `TooManyTargetGroups` error.
 
 The audit therefore counts, per permanent region, the total and orphaned (unattached) target groups and compares them against the regional quota. It posts a Slack warning when utilization reaches `ELBV2_TG_USAGE_WARN_PERCENT` (default 80%) of the quota, or when the number of orphaned target groups reaches `ELBV2_TG_ORPHAN_WARN` (default 50). In the CI regions, these orphaned target groups are deleted automatically by the [nightly cleanup](.github/workflows/aws_nightly_cleanup.yml).
+
+## CI trust boundary
+
+A job that runs repository-supplied code must not hold a GitHub write credential.
+
+"Repository-supplied code" is broader than it looks. It is not only the scripts in the
+tree: it is asdf plugins named by `.tool-versions`, pre-commit hooks named by
+`.pre-commit-config.yaml`, terraform providers, `go mod tidy`, anything a build resolves
+from a lockfile. On a `pull_request` run all of it comes from the contributor's branch,
+which for a Renovate pull request means it comes from whatever the dependency update
+pulled in. INC-7027 was a malicious payload in a dependency update; it only had to be
+proposed, not merged.
+
+Pinning actions to a SHA does not address this. Pinning fixes *which* code runs, not what
+that code can reach once it runs.
+
+### The rule
+
+- A job that runs repository code holds no App token, no `secrets.*` it does not strictly
+  need, and sets `persist-credentials: false` so its own `GITHUB_TOKEN` is not left in
+  `.git/config` for that code to find.
+- The credential lives in a separate job that runs only SHA-pinned third-party actions.
+- Installation tokens name `repositories:` explicitly rather than relying on the token
+  action's default.
+- The token is minted last, after any untrusted input has been handled, so it is not alive
+  while that happens and no hook can have planted a `PATH` shim or `BASH_ENV` first.
+- Work crosses the boundary as data, not as execution: the unprivileged job emits a patch
+  artifact, the privileged one applies it. Applying a patch does not execute it, and
+  `git apply` refuses paths outside the work tree.
+
+### The shared implementation
+
+[`commit-patch-global.yml`](.github/workflows/commit-patch-global.yml) is the privileged
+half. It downloads the patch, refuses what it should not commit, applies it, mints a
+repository-scoped token and commits through the API.
+
+```yaml
+jobs:
+    build:
+        # runs the repository's code; no write credential, no App token
+        # uploads its result as a patch artifact
+        ...
+
+    commit:
+        needs: build
+        if: needs.build.outputs.has_changes == 'true'
+        uses: camunda/infraex-common-config/.github/workflows/commit-patch-global.yml@<sha>
+        with:
+            artifact-name: ${{ needs.build.outputs.artifact_name }}
+            head-sha: ${{ github.event.pull_request.head.sha }}
+            head-ref: ${{ github.event.pull_request.head.ref }}
+            commit-message: 'chore: apply automated fixes'
+        secrets:
+            vault-addr: ${{ secrets.VAULT_ADDR }}
+            vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+            vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+```
+
+Tune `max-patch-bytes`, `max-changed-lines` and `refuse-paths-regex` to the producing job:
+a formatter's output should stay small and human-readable, a generator rewriting a fixture
+corpus legitimately runs to megabytes. The guards bound a runaway and refuse patches the
+commit step would silently corrupt; they are not an injection defence, since a hostile
+patch needs three lines rather than a large one.
+
+### What this does not fix
+
+Two residuals, worth stating so the boundary is not read as stronger than it is.
+
+On `pull_request`, GitHub evaluates the workflow file **from the head branch**. Anyone
+with push access can therefore edit the privileged job itself. That is irreducible for any
+workflow holding a secret, and is bounded by fork pull requests receiving no secrets at
+all, plus review of anything touching `.github/`.
+
+If the unprivileged job keeps a Vault approle for cloud credentials, and that approle can
+read the path where the GitHub App private key lives, branch code that exfiltrates it can
+mint a token regardless. Splitting the jobs removes the token sitting next to the code; it
+does not remove that path. Where it applies, scope the Vault role away from the App key.


### PR DESCRIPTION
## Why

Two workflows now end the same way:

| | `lint-global.yml` (`autofix-apply`) | `camunda-deployment-references` `internal_global_maintenance.yml` (`commit`) |
|---|---|---|
| download patch artifact | yes | yes |
| byte cap | yes | yes |
| changed-line cap | **yes** | no |
| binary / mode refusal | yes | yes |
| refuse CI definitions | no | **yes** |
| assert branch has not moved | no | **yes** |
| `git apply`, mint token, commit via API | yes | yes |

Same shape, and **already drifted**: each one carries a guard the other lacks. That is the argument for doing this now rather than later — the divergence is not hypothetical, it happened within days of the second copy being written.

## What

`commit-patch-global.yml`: the privileged half of the split, once, with the union of the guards, each behind an input.

- `max-patch-bytes` — always on. Sized to the producing job: a formatter's output is kilobytes, a generator rewriting a fixture corpus is megabytes.
- `max-changed-lines` — `0` disables. Right setting whenever the job legitimately rewrites generated files; a line count says nothing useful about machine-written JSON.
- `refuse-paths-regex` — empty disables. Deliberately not defaulted to the CI-definition pattern: a formatter reformatting workflow YAML writes `.github/workflows/` **legitimately**, and would be refused. It is the caller that knows whether those paths are in scope.
- Binary hunks and mode changes — always refused. `getsentry/action-github-commit` sends content as `Buffer.from(content).toString()` and hardcodes mode `100644`, so both would be committed silently corrupted while the patch itself carries them faithfully. Deletions are fine, the action handles them with `sha: null`.
- The head SHA is checked out and asserted still to be the branch tip before committing; the token is minted last and named to the calling repository.

The README gains a **CI trust boundary** section — the rule the code has only ever carried as comments. What counts as repository-supplied code (asdf plugins, pre-commit hooks, terraform providers, `go mod tidy` — not just scripts in the tree), why SHA pinning does not address it, and how work crosses the boundary as data rather than execution.

It also states the two residuals, so the boundary is not read as stronger than it is: on `pull_request` the workflow file itself comes from the head branch, and a Vault approle able to read the App private key path defeats the split regardless of where the token sits.

## No callers yet, deliberately

A reusable workflow calling another by relative path resolves against the **calling** repository, not this one. `lint-global.yml` therefore has to name `camunda/infraex-common-config/.github/workflows/commit-patch-global.yml@<sha>` — a SHA that only exists once this merges. Standard bootstrap; the callers follow in their own pull requests:

1. this one — the workflow and the rule;
2. `lint-global.yml` switches to it, which exercises it across all nine consuming repositories;
3. `camunda-deployment-references` `internal_global_maintenance.yml` switches to it, on `main` and the three stable branches.

Step 2 is the one to watch: `lint-global` is consumed by every InfraEx repository, so it deserves its own review and a period of observation before step 3.

## Validation

`actionlint` 1.7.12, `yamllint`, `yamlfmt` and `pre-commit` pass. `zizmor` is clean at the `pedantic` persona — it caught a template injection in the first draft of this file, `${{ inputs.artifact-name }}` expanded inline into a `run:` block, which is now passed through the environment.

The logic itself is not new: it is the code merged in camunda/camunda-deployment-references#3026, whose success path was exercised end to end against scratch repositories — patch built in one clone, guards run and applied in another, `git ls-files -om` confirming the commit step would collect exactly the changed files — and whose failure path has since been observed in production, with the privileged job correctly skipped when the producing job failed.

## Context

Relates to camunda/camunda-deployment-references#3026, #3041, camunda/team-infrastructure-experience#1231, camunda/team-infrastructure#1126, INC-7027.