### PR TITLE
ci(lint-global): declare the Vault secrets so callers can stop inheriting [ready]

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -23,6 +23,24 @@ on:
                     bulk content (binaries, generated blobs) that a line count does not.
                 default: 65536
                 type: number
+        # Declared so callers can pass these three explicitly instead of `secrets: inherit`,
+        # which hands the called workflow every secret the calling repository holds -- Docker
+        # Hub, registry and cloud credentials included -- when all it needs is the AppRole that
+        # mints the auto-fix App token.
+        #
+        # All three are optional: a repository that never auto-fixes (no `autofix-actor` run)
+        # never reaches the job that reads them. Existing callers using `secrets: inherit` keep
+        # working unchanged, since inherit satisfies declared secrets too.
+        secrets:
+            VAULT_ADDR:
+                description: Vault server URL, used only by the auto-fix job.
+                required: false
+            VAULT_ROLE_ID:
+                description: Vault AppRole role ID, used only by the auto-fix job.
+                required: false
+            VAULT_SECRET_ID:
+                description: Vault AppRole secret ID, used only by the auto-fix job.
+                required: false
 
 # The auto-fix commit is created with a dedicated GitHub App token in a separate job,
 # never with GITHUB_TOKEN. GITHUB_TOKEN therefore stays read-only for the whole run,


### PR DESCRIPTION
Unblocks the `secrets-inherit` half of the zizmor burn-down in the consumer repositories.

## Problem

`lint-global.yml` reads `secrets.VAULT_ADDR`, `secrets.VAULT_ROLE_ID` and `secrets.VAULT_SECRET_ID` in the auto-fix job, but declares no `secrets:` block under `workflow_call`. A reusable workflow can only see secrets that were declared *or* inherited, so every caller is forced into:

```yaml
    lint:
        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@... # 2.0.1
        secrets: inherit
```

`inherit` passes **every** secret the calling repository holds — Docker Hub credentials, registry machine users, cloud keys — to a workflow that needs one AppRole. zizmor flags it as `secrets-inherit` in each of camunda/keycloak, camunda/c8-sm-checks, camunda/infraex-terraform and camunda/team-infrastructure-experience.

The exposure is not theoretical for this particular workflow: the `pre-commit` job installs and executes hook code coming from the repository under test. #550 already took the App token away from that job for exactly that reason; the inherited secret set is the remaining part.

## Change

The three secrets are declared, all `required: false`.

- A repository that never auto-fixes never reaches the job that reads them, so optional is correct rather than lenient.
- Existing callers are unaffected: `secrets: inherit` satisfies declared secrets too. No consumer has to move in the same release.

After this lands and is tagged, consumers can switch to:

```yaml
        secrets:
            VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
            VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
            VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
```

`todo-checker-global.yml` needs no equivalent change: it reads no secret at all, so its callers can simply drop the `secrets: inherit` line, which is being done in the same round of consumer PRs.

## Verification

`pre-commit run --all-files` clean, actionlint and zizmor included.
