### PR TITLE
fix(todo-checker): paginate the PR comment lookup

### DIFF
--- a/.github/workflows/todo-checker-global.yml
+++ b/.github/workflows/todo-checker-global.yml
@@ -91,7 +91,14 @@ jobs:
                   set -e
 
                   echo "📥 Getting existing PR comments"
-                  gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" > comments.json
+                  # --paginate is required: the endpoint returns 30 comments per page and page 1
+                  # holds the OLDEST, so on any pull request past 30 review comments this workflow
+                  # stopped seeing its own comments -- posting a duplicate on every run and never
+                  # honouring the 👎 acknowledgement, leaving the check permanently red.
+                  # --slurp would yield an array of pages, which breaks the `.[]` lookup below, so
+                  # the pages are flattened into one array instead.
+                  gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
+                    --paginate --jq '.[]' | jq -s '.' > comments.json
 
                   echo "🔁 Processing TODOs with git blame verification"
                   echo "0" > todo_count.txt


### PR DESCRIPTION
The existing-comment lookup fetches a single page:

```bash
gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" > comments.json
```

The endpoint returns **30 items per page** and page 1 holds the **oldest**, so on any pull request past 30 review comments the workflow cannot see the comments it posted itself.

## Observed

On camunda/camunda-deployment-references#2975, which has 33 review comments:

```
$ gh api "repos/.../pulls/2975/comments" --jq "length"
30                                          # one page

$ gh api "repos/.../pulls/2975/comments" \
    --jq "[.[] | select(.user.login==\"github-actions[bot]\"
           and (.body|contains(\"A new Todo was discovered\")))] | length"
0                                           # what the workflow sees

$ gh api "repos/.../pulls/2975/comments" --paginate ... | length
2                                           # what is actually there
```

Two consequences:

1. **A duplicate reminder on every run.** The lookup finds nothing, so it re-posts. That PR now carries two identical bot comments on the same line.
2. **The 👎 escape hatch is unreachable.** `REACT_DOWN` is read off a comment that never appears in `comments.json`, so the reaction is never seen and `found_remaining_todos` never drops. The step ends on `exit "$found_remaining_todos"`, so the check fails on every run with nothing the author can do about it.

The second is the real problem: the workflow offers exactly one way to acknowledge a deliberate TODO, and it stops working precisely when the discussion is long enough to need it. I hit this by adding one intentional, ticket-tracked TODO to a PR that already had a long review thread.

## Fix

```bash
gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
  --paginate --jq ".[]" | jq -s "." > comments.json
```

`--slurp` is deliberately not used: it returns an array of pages, so `comments.json` becomes `[[...],[...]]` and the `yq e ".[] | select(...)"` lookup below silently matches nothing — the same class of bug, differently spelled. Flattening the pages into one array keeps the existing lookup untouched.

Verified against the same PR: the corrected form produces a 33-element array and the `yq` selector then finds both bot comments.

`jq` is already used by this step (`jq -c "." todos.json`), so nothing new is required.

## Blast radius

Every repository consuming `todo-checker-global.yml` — the check is currently unsatisfiable on any of their PRs that pass 30 review comments.