### PR TITLE
chore(pre-commit): drop redundant renovate language_version pin [ready]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,8 +32,6 @@ repos:
             # default.json5 -- the preset every consumer repository extends -- was
             # never validated. Keep the upstream alternative verbatim and add ours.
             files: (^|/).?renovate(?:rc)?(?:\.json5?)?$|^default\.json5$
-            # TODO : revert this when https://github.com/renovatebot/pre-commit-hooks/issues/2460 is fixed
-            language_version: lts
 
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
       rev: 0.2.3


### PR DESCRIPTION
## Description

`renovatebot/pre-commit-hooks` no longer needs the `language_version: lts` override: [#2460](https://github.com/renovatebot/pre-commit-hooks/issues/2460) was closed by [#2628](https://github.com/renovatebot/pre-commit-hooks/pull/2628), which sets `language_version: lts` in the hook's own `.pre-commit-hooks.yaml`. The default is present both at our pinned rev `43.288.0` and on upstream `main`, so the local pin and its TODO only duplicate upstream.

The hook itself stays: this repository ships `default.json5` (the preset every consumer extends) and `.github/renovate.json5`, and `camunda-deployment-references` still runs `renovate-config-validator` on `main` (rev `44.5.2`) — without the override, which this change now matches.

## Verification

After removing the override, with a cleaned pre-commit cache:

- the hook environment still resolves to `node_env-lts`, i.e. the upstream default applies;
- `pre-commit run --all-files` passes (`actionlint` skipped locally: unrelated Go toolchain mismatch, `go1.26.5` vs tool `go1.26.4`).

## Follow-up (not in this PR)

`camunda/infra-global-github-actions` still carries the same redundant `language_version: lts` line and can get the identical cleanup.