### PR TITLE
feat(renovate): centralize Aurora MySQL versioning on the custom datasource

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -315,6 +315,22 @@
       ],
       versioning: 'regex:^camunda-platform(-\\d+\\.\\d+)?-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
     },
+    {
+      // Aurora MySQL engine versions are compound (e.g. 8.4.mysql_aurora.8.4.7),
+      // so `loose` mis-sorts them (it puts 8.4.10 below 8.4.7). Track the Aurora
+      // engine version after `mysql_aurora.` as major.minor.patch, ignoring the
+      // MySQL-compatibility prefix (8.4/8.0/5.7) — the Aurora-major sequence
+      // (v2→v3→v8) is monotonic, so this orders every published version
+      // correctly, classifies update types accurately, and surfaces cross-line
+      // jumps as majors (caught by the aurora-mysql breaking-change guard above).
+      // Centralised here so consumers only need
+      // `datasource=custom.aurora-mysql-camunda depName=aurora-mysql` with no
+      // inline `versioning=`.
+      matchDatasources: [
+        'custom.aurora-mysql-camunda',
+      ],
+      versioning: 'regex:^\\d+\\.\\d+\\.mysql_aurora\\.(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+    },
   ],
   'customDatasources': {
     'rosa-camunda': {


### PR DESCRIPTION
## Why

`custom.aurora-mysql-camunda` returns compound Aurora MySQL versions (e.g. `8.4.mysql_aurora.8.4.7`). Renovate's default `loose` versioning mis-orders these — it sorts `8.4.10` below `8.4.7`. Until now the only fix was an inline `versioning=regex:…` on each consumer's annotation (e.g. in `camunda-deployment-references`), which is easy to get wrong and easy to omit.

## What

Attach the versioning to the datasource itself via a `matchDatasources: ['custom.aurora-mysql-camunda']` packageRule, so it applies everywhere the datasource is used:

```
versioning: 'regex:^\d+\.\d+\.mysql_aurora\.(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$'
```

It tracks the Aurora engine version after `mysql_aurora.` as major.minor.patch (ignoring the MySQL-compat prefix `8.4`/`8.0`/`5.7`). Validated against all 32 published versions in [`aurora_mysql_versions.txt`](https://camunda.github.io/camunda-deployment-references/aurora_mysql_versions.txt): every version matches, ordering is correct (`8.4.10 > 8.4.7`), update types are accurate (`8.4.7→8.4.8` = patch, `→8.5.0` = minor, `→9.0.0` = major), and cross-line jumps surface as majors — caught by the `aurora-mysql` breaking-change guard added earlier. Consumers now only need `datasource=custom.aurora-mysql-camunda depName=aurora-mysql`, with no inline `versioning=`. Refs camunda/team-infrastructure-experience#1209.

Validated with `renovate-config-validator --strict` (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
